### PR TITLE
Fix the regex used to find the `license_id`

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -473,7 +473,7 @@ HELP
 
     def approve_license
       license_path = "#{@path}/Contents/Resources/English.lproj/License.rtf"
-      license_id = IO.read(license_path).match(/^EA\d{4}/)
+      license_id = IO.read(license_path).match(/\bEA\d{4}\b/)
       license_plist_path = '/Library/Preferences/com.apple.dt.Xcode.plist'
       `sudo rm -rf #{license_plist_path}`
       `sudo /usr/libexec/PlistBuddy -c "add :IDELastGMLicenseAgreedTo string #{license_id}" #{license_plist_path}`


### PR DESCRIPTION
Xcode 8 seems to break the regex, because `EA` doesn't come at the start of the line.

For me, that file looks like:
```
$ cat /Applications/Xcode_8.app/Contents/Resources/English.lproj/License.rtf | tail -n3

\fs16 \cf0 EA1421\
8/24/16}%
```

So, I changed the regex to look for word boundaries instead.

Here's the testing I did (in irb), where you can see the old regex (the first `IO.read…`) fails to match, but the new regex succeeds:
```
>> p = "/Applications/Xcode_8.app/Contents/Resources/English.lproj/License.rtf"
=> "/Applications/Xcode_8.app/Contents/Resources/English.lproj/License.rtf"

>> IO.read(p).match(/^EA\d{4}/)
=> nil

>> IO.read(p).match(/\bEA\d{4}\b/)
=> #<MatchData "EA1421">
```


NOTE: I'm not sure if this is actually failing for everybody or not, because I don't run `xcode-install` directly.  But, I use these same "approve" steps in my own script, which broke with Xcode 8 just now.  So, I assume the same issue will happen in `xcode-install`.  If so, this should fix it.