### PR TITLE
Fix prerelease parsing for Xcode 8.1 beta

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -298,7 +298,7 @@ HELP
       links = links.map { |pre| Xcode.new_prerelease(pre[2].strip.gsub(/.*Xcode /, ''), pre[0], pre[3]) }
 
       if links.count == 0
-        rg = %r{Xcode.* beta.*<\/p>}
+        rg = %r{platform-title.*Xcode.* beta.*<\/p>}
         scan = body.scan(rg)
 
         if scan.count == 0

--- a/spec/fixtures/devcenter/xcode-20160922.html
+++ b/spec/fixtures/devcenter/xcode-20160922.html
@@ -1,0 +1,878 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta name="Author" content="Apple Inc." />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7, IE=9">
+<link rel="shortcut icon" href="/favicon.ico" />
+<link rel="icon" href="/favicon.ico" />
+<link rel="mask-icon" href="/apple-logo.svg" color="#333333">
+
+<link rel="stylesheet" href="/assets/styles/globalnav.css" type="text/css" />
+<link rel="stylesheet" href="/assets/styles/global.css" type="text/css" />
+
+<script src="https://devimages.apple.com.edgekey.net/assets/scripts/lib/jquery/jquery-1.11.0.min.js"></script>
+<script src="https://devimages.apple.com.edgekey.net/assets/scripts/lib/jquery/jquery.retinate.js" type="text/javascript" charset="utf-8"></script>
+<!--[if lt IE 9]>
+    <link rel="stylesheet" href="/assets/styles/oldie.css" type="text/css" />
+    <script src="/assets/scripts/html5.js"></script>
+<![endif]-->
+<script src="/assets/scripts/lg-search.js"></script>
+<script src="/assets/scripts/global.js"></script>
+
+    <link rel="stylesheet" href="https://www.apple.com/wss/fonts?family=Myriad+Set+Pro&v=2" type="text/css" />
+
+    <title>Download - Apple Developer</title>
+    <meta name="omni_page" content="Download - Apple Developer">
+    <link rel="stylesheet" href="/download/styles/download.css" type="text/css" />
+
+                    <script type="text/javascript">
+            (function(window, undefined) {
+                window.userIsMemberOfProgram = true;
+            }(window));
+        </script>
+            <script type="text/javascript" src="/download/scripts/download.js"></script>
+    
+</head>
+<body>
+    <input type="checkbox" id="ac-gn-menustate" class="ac-gn-menustate">
+<nav id="ac-globalnav" class="no-js" role="navigation" aria-label="Global Navigation" data-hires="false" data-analytics-region="global nav" lang="en-US">
+    <div class="ac-gn-content">
+        <ul class="ac-gn-header">
+            <li class="ac-gn-item ac-gn-menuicon"> <label class="ac-gn-menuicon-label" for="ac-gn-menustate" aria-hidden="true">
+                    <span class="ac-gn-menuicon-bread ac-gn-menuicon-bread-top">
+                        <span class="ac-gn-menuicon-bread-crust ac-gn-menuicon-bread-crust-top"></span>
+                    </span>
+                    <span class="ac-gn-menuicon-bread ac-gn-menuicon-bread-bottom">
+                        <span class="ac-gn-menuicon-bread-crust ac-gn-menuicon-bread-crust-bottom"></span>
+                    </span>
+                </label>
+                <a href="#ac-gn-menustate" class="ac-gn-menuanchor ac-gn-menuanchor-open" id="ac-gn-menuanchor-open"> <span class="ac-gn-menuanchor-label">Open Menu</span> </a>
+                <a href="#" class="ac-gn-menuanchor ac-gn-menuanchor-close" id="ac-gn-menuanchor-close"> <span class="ac-gn-menuanchor-label">Close Menu</span> </a>
+            </li>
+            <li class="ac-gn-item ac-gn-apple">
+                <a class="ac-gn-link ac-gn-link-apple" href="/" id="ac-gn-firstfocus-small"> <span class="ac-gn-link-text">Apple Developer</span> </a>
+            </li>
+            <li class="ac-gn-item ac-gn-bag ac-gn-bag-small" id="ac-gn-bag-small">
+                <a class="ac-gn-link ac-gn-link-bag" href="/account/"> <span class="ac-gn-link-text">Account</span> <span class="ac-gn-bag-badge"></span> </a> <span class="ac-gn-bagview-caret ac-gn-bagview-caret-large"></span> </li>
+        </ul>
+        <ul class="ac-gn-list">
+            <li class="ac-gn-item ac-gn-apple">
+                <a class="ac-gn-link ac-gn-link-apple" href="/" id="ac-gn-firstfocus"> <span class="ac-gn-link-text">Apple Developer</span> </a>
+            </li>
+            <li class="ac-gn-item ac-gn-item-menu ac-gn-discover">
+                <a class="ac-gn-link" href="/discover/"> <span>Discover</span> </a>
+            </li>
+            <li class="ac-gn-item ac-gn-item-menu ac-gn-design">
+                <a class="ac-gn-link" href="/design/"> <span>Design</span> </a>
+            </li>
+            <li class="ac-gn-item ac-gn-item-menu ac-gn-develop">
+                <a class="ac-gn-link" href="/develop/"> <span>Develop</span> </a>
+            </li>
+            <li class="ac-gn-item ac-gn-item-menu ac-gn-distribute">
+                <a class="ac-gn-link" href="/distribute/"> <span>Distribute</span> </a>
+            </li>
+            <li class="ac-gn-item ac-gn-item-menu ac-gn-support">
+                <a class="ac-gn-link" href="/support/"> <span>Support</span> </a>
+            </li>
+            <li class="ac-gn-item ac-gn-item-menu ac-gn-account">
+                <a class="ac-gn-link" href="/account/"> <span>Account</span> </a>
+            </li>
+            <li class="ac-gn-item ac-gn-item-menu ac-gn-search" role="search">
+                <a id="ac-gn-search-button" class="ac-gn-link ac-gn-link-search" href="/search/" aria-label="Search developer.apple.com"> <span class="ac-gn-search-placeholder" aria-hidden="true">Search</span> </a>
+            </li>
+        </ul>
+        <aside id="ac-gn-searchview" class="ac-gn-searchview" role="search" data-analytics-region="search">
+            <div class="ac-gn-searchview-content">
+                <form id="ac-gn-searchform" class="ac-gn-searchform" action="/search/" method="get">
+                    <div class="ac-gn-searchform-wrapper"> <input id="ac-gn-searchform-input" class="ac-gn-searchform-input" type="text" name="q" placeholder="Search" data-placeholder-long="Search for documentation, videos, and more" autocorrect="off" autocapitalize="off" autocomplete="off" spellcheck="false" /> <button id="ac-gn-searchform-submit" class="ac-gn-searchform-submit" type="submit" disabled aria-label="Submit"></button> <button id="ac-gn-searchform-reset" class="ac-gn-searchform-reset" type="reset" disabled aria-label="Clear Search"></button> </div>
+                </form>
+                <aside id="ac-gn-searchresults" class="ac-gn-searchresults" data-string-quicklinks="Quick Links" data-string-suggestions="Suggested Searches" data-string-noresults="Hit enter to search.">
+
+                </aside>
+            </div> <button id="ac-gn-searchview-close" class="ac-gn-searchview-close" aria-label="Close Search">
+                    <span class="ac-gn-searchview-close-wrapper">
+                        <span class="ac-gn-searchview-close-left"></span>
+                        <span class="ac-gn-searchview-close-right"></span>
+                    </span>
+                </button> </aside>
+    </div>
+</nav>
+<div id="ac-gn-curtain" class="ac-gn-curtain"></div>
+<div id="ac-gn-placeholder" class="ac-nav-placeholder"></div>
+<script type="text/javascript" src="/assets/scripts/ac-globalnav.built.js"></script>
+
+    <div id="top">
+<!-- SiteCatalyst code version: H.8. Copyright 1997-2006 Omniture, Inc. -->
+<script type="text/javascript">
+/* RSID: */
+var s_account="appleglobal,appleusdeveloper"
+</script>
+
+<script type="text/javascript" src="https://www.apple.com/metrics/scripts/s_code_h.js"></script>
+<script type="text/javascript">
+s.pageName= AC && AC.Tracking && AC.Tracking.pageName();
+s.channel="www.us.developer"
+
+/************* DO NOT ALTER ANYTHING BELOW THIS LINE ! **************/
+var s_code=s.t();if(s_code)document.write(s_code)</script>
+<!-- End SiteCatalyst code version: H.8. -->
+</div>
+
+    <main id="main" class="main" role="main">
+
+        <section class="grid">
+            <section class="row">
+                <section class="col-100">
+                                        <nav class="logout-bar">
+                        <ul>
+                            <li>Johnny Appleseed</li>
+                            <li> | </li>
+                            <li><a href="/logout/?return=%2Fios%2Fdownload%2Fwwdc%2F" class="sign-out">Sign out</a></li>
+                        </ul>
+                    </nav>
+                                        <h1 class="text-center">Downloads</h1>
+                    <p class=" text-center center width-75 intro">Get the latest beta releases of Xcode, iOS, macOS, watchOS, tvOS, and more.</p>
+                </section>
+            </section>
+        </section>
+
+                        <section class="grid">
+                <div class="row">
+                    <div class="col-100">
+                <!-- FEATURED TABLE -->             
+                        <p class="footnote">Your use of Apple beta software is subject to and licensed only under the terms and conditions of the Apple Developer Program License Agreement, including any applicable consent to collect diagnostic data set forth therein. If you have not agreed to the Apple Developer Program License Agreement, you are not permitted to use this software. Refer to the software installation guides for complete instructions.</p>
+                        
+                    </div>
+                </div>
+                <div class="row">
+                    <section class="table">
+                        <section class="table-top-sticky">
+                            <section class="table-header row">
+                                <section class="col-60">
+
+                                    <!-- Table title -->
+                                    <span>Featured Downloads</span>
+
+                                </section>
+                                <section class="col-40">
+                                <ul class="download-details">
+                                    <li class="release-notes">&nbsp;</li>
+                                    <li class="build-number">Build</li>
+                                    <li class="published-date">Date</li>
+                                    <li class="download">&nbsp;</li>
+                                </ul>
+                            </section>
+                            </section>
+                        </section>
+
+                        <ul class="table-rows">
+
+                            <!-- Xcode 8.1 BETA -->
+                            <li class="table-row">
+                                <section class="col-60">
+                                    <p><span class="platform-title">Xcode</span> 8.1 beta</p>
+                                    <p class="smaller">Includes the SDKs for iOS 10.1 beta, macOS 10.12.1 beta, watchOS 3.1 beta, and tvOS 10.0.1 beta. <br>Xcode 8.1 beta requires OS X 10.11.5 or later.</p>
+                                </section>
+                                <section class="col-40">
+                                    <ul class="download-details">
+                                        <li class="release-notes"><a href="/go/?id=xcode-8.1-beta-rn">Release Notes</a></li>
+                                        <li class="build-number">8T29o</li>
+                                        <li class="published-date">Sep 21, 2016</li>
+                                        <li class="download"><button class="direct-download" value="/services-account/download?path=/Developer_Tools/Xcode_8.1_beta/Xcode_8.1_beta.xip">Download</button></li>
+                                    </ul>
+                                </section>
+                            </li>
+
+                            <!-- macOS BETA -->
+                            <li class="table-row">
+                                <section class="col-60">
+                                    <p><span class="platform-title">macOS</span> 10.12.1 beta</p>
+                                    <p class="smaller">Run the Sierra Developer Beta Access Utility to download the latest macOS Sierra beta.</p>
+                                </section>
+                                <section class="col-40">
+                                    <ul class="download-details">
+                                        <li class="release-notes"><a href="/go/?id=macos-10.12.1-beta-rn">Release Notes</a></li>
+                                        <li class="build-number">16B2327e</li>
+                                        <li class="published-date">Sep 21, 2016</li>
+                                        <li class="download"><button class="direct-download" value="/services-account/download?path=/OS_X/macOS_Sierra_Developer_Beta_Access_Utility/macOS_Sierra_Developer_Beta_Access_Utility.dmg">Download</button></li>
+                                    </ul>
+                                </section>
+                            </li>
+
+                            <!-- iOS BETA -->
+                            <li class="table-row parent-section">
+                                <section class="col-60">
+                                    <p><span class="platform-title">iOS</span> 10.1 beta<span class="violator violator-inline violator-alt">Preferred</span></p>
+                                    <p class="smaller">Install Configuration Profile directly on any iOS device and receive OTA updates.</p>
+                                </section>
+                                <section class="col-40">
+                                    <ul class="download-details">
+                                        <li class="release-notes"><a href="/go/?id=ios-10.1-sdk-rn">Release Notes</a></li>
+                                        <li class="build-number">14B55c</li>
+                                        <li class="published-date">Sep 21, 2016</li>
+                                        <li class="download"><button class="direct-download" value="/services-account/download?path=/iOS/iOS_10.1_beta_Configuration_Profile/iOS_10_beta_Configuration_Profile.mobileconfig">Download</button></li>
+                                    </ul>
+                                </section>
+                            </li>
+
+                                <li class="table-row sub-section">
+                                    <section class="col-60">
+                                        <p>iOS Restore Images</p>
+                                        <p class="smaller">Install via iTunes.</p>
+                                    </section>
+                                    <section class="col-40">
+                                        <ul class="download-details">
+                                            <li class="download"><button class="drop-down">See all</button></li>
+                                        </ul>
+                                    </section>
+
+                                <!-- iOS DOWNLOADS -->
+                                <ul class="sub-list col-100">
+                                    </li>
+                                    <li class="table-row">
+                                            <section class="col-60">
+                                                <p>iPhone 7</p>
+                                                <p class="smaller">Restore image for listed devices.</p>
+                                            </section>
+                                            <section class="col-40">
+                                                <ul class="download-details">
+                                                    <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.1seed/031-81785-20160927-6F8AAF7E-7DB3-11E6-AAC1-723B34D2D062/iPhone9,3_10.1_14B55c_Restore.ipsw">Download</button></li>
+                                                </ul>
+                                            </section>
+                                    </li>
+                                    <li class="table-row">
+                                            <section class="col-60">
+                                                <p>iPhone 7 Plus</p>
+                                                <p class="smaller">Restore image for listed devices.</p>
+                                            </section>
+                                            <section class="col-40">
+                                                <ul class="download-details">
+                                                    <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.1seed/031-81789-20160927-6F8DA512-7DB3-11E6-844F-753B34D2D062/iPhone9,2_10.1_14B55c_Restore.ipsw">Download</button></li>
+                                                </ul>
+                                            </section>
+                                    </li>                                                               
+                                    <li class="table-row">
+                                        <section class="col-60">
+                                            <p>iPhone SE</p>
+                                            <p class="smaller">Restore image for listed devices.</p>
+                                        </section>
+                                        <section class="col-40">
+                                            <ul class="download-details">
+                                                <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.1seed/031-81786-20160927-6F8C031A-7DB3-11E6-B48E-743B34D2D062/iPhoneSE_10.1_14B55c_Restore.ipsw">Download</button></li>
+                                            </ul>
+                                        </section>
+                                    </li>
+                                    <li class="table-row">
+                                        <section class="col-60">
+                                            <p>iPhone 6s, iPhone 6</p>
+                                            <p class="smaller">Restore image for listed devices.</p>
+                                        </section>
+                                        <section class="col-40">
+                                            <ul class="download-details">
+                                                <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.1seed/031-81790-20160927-6F87C39A-7DB3-11E6-973E-763B34D2D062/iPhone_4.7_10.1_14B55c_Restore.ipsw">Download</button></li>
+                                            </ul>
+                                        </section>
+                                    </li>
+                                    <li class="table-row">
+                                        <section class="col-60">
+                                            <p>iPhone 6s Plus, iPhone 6 Plus</p>
+                                            <p class="smaller">Restore image for listed devices.</p>
+                                        </section>
+                                        <section class="col-40">
+                                            <ul class="download-details">
+                                                <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.1seed/031-81791-20160927-6F8D80D2-7DB3-11E6-932E-773B34D2D062/iPhone_5.5_10.1_14B55c_Restore.ipsw">Download</button></li>
+                                            </ul>
+                                        </section>
+                                    </li>
+                                    <li class="table-row">
+                                        <section class="col-60">
+                                            <p>iPhone 5s</p>
+                                            <p class="smaller">Restore image for listed devices.</p>
+                                        </section>
+                                        <section class="col-40">
+                                            <ul class="download-details">
+                                                <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.1seed/031-81776-20160927-6F873A1A-7DB3-11E6-A5AC-6D3B34D2D062/iPhone_4.0_64bit_10.1_14B55c_Restore.ipsw">Download</button></li>
+                                            </ul>
+                                        </section>
+                                    </li>
+                                    <li class="table-row">
+                                        <section class="col-60">
+                                            <p>iPhone 5c, iPhone 5</p>
+                                            <p class="smaller">Restore image for listed devices.</p>
+                                        </section>
+                                        <section class="col-40">
+                                            <ul class="download-details">
+                                                <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.1seed/031-81770-20160927-6F84EF62-7DB3-11E6-AED1-653B34D2D062/iPhone_4.0_32bit_10.1_14B55c_Restore.ipsw">Download</button></li>
+                                            </ul>
+                                        </section>
+                                    </li>
+                                    <li class="table-row">
+                                        <section class="col-60">
+                                            <p>9.7‑inch iPad Pro</p>
+                                            <p class="smaller">Restore image for listed devices.</p>
+                                        </section>
+                                        <section class="col-40">
+                                            <ul class="download-details">
+                                                <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.1seed/031-81778-20160927-6F836FAC-7DB3-11E6-B731-6E3B34D2D062/iPadPro_9.7_10.1_14B55c_Restore.ipsw">Download</button></li>
+                                            </ul>
+                                        </section>
+                                    </li>
+                                    <li class="table-row">
+                                        <section class="col-60">
+                                            <p>12.9‑inch iPad Pro</p>
+                                            <p class="smaller">Restore image for listed devices.</p>
+                                        </section>
+                                        <section class="col-40">
+                                            <ul class="download-details">
+                                                <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.1seed/031-81769-20160927-6F852B26-7DB3-11E6-BFC8-633B34D2D062/iPadPro_12.9_10.1_14B55c_Restore.ipsw">Download</button></li>
+                                            </ul>
+                                        </section>
+                                    </li>
+                                    <li class="table-row">
+                                        <section class="col-60">
+                                            <p>iPad mini 4, iPad Air 2, iPad mini 3</p>
+                                            <p class="smaller">Restore image for listed devices.</p>
+                                        </section>
+                                        <section class="col-40">
+                                            <ul class="download-details">
+                                                <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.1seed/031-81775-20160927-6F84C410-7DB3-11E6-BF57-6B3B34D2D062/iPad_64bit_TouchID_10.1_14B55c_Restore.ipsw">Download</button></li>
+                                            </ul>
+                                        </section>
+                                    </li>
+                                    <li class="table-row">
+                                        <section class="col-60">
+                                            <p>iPad Air, iPad mini 2</p>
+                                            <p class="smaller">Restore image for listed devices.</p>
+                                        </section>
+                                        <section class="col-40">
+                                            <ul class="download-details">
+                                                <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.1seed/031-81772-20160927-6F8913E4-7DB3-11E6-BEB2-673B34D2D062/iPad_64bit_10.1_14B55c_Restore.ipsw">Download</button></li>
+                                            </ul>
+                                        </section>
+                                    </li>
+                                    <li class="table-row">
+                                        <section class="col-60">
+                                            <p>iPad <span class="lighter">(4th generation Model)</span></p>
+                                            <p class="smaller">Restore image for listed devices.</p>
+                                        </section>
+                                        <section class="col-40">
+                                            <ul class="download-details">
+                                                <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.1seed/031-81782-20160927-6F85D81E-7DB3-11E6-A0D4-703B34D2D062/iPad_32bit_10.1_14B55c_Restore.ipsw">Download</button></li>
+                                            </ul>
+                                        </section>
+                                    </li>
+                                    <li class="table-row">
+                                        <section class="col-60">
+                                            <p>iPod touch <span class="lighter">(6th generation)</span></p>
+                                            <p class="smaller">Restore image for listed devices.</p>
+                                        </section>
+                                        <section class="col-40">
+                                            <ul class="download-details">
+                                                <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.1seed/031-81773-20160927-6F83062A-7DB3-11E6-A227-693B34D2D062/iPodtouch_10.1_14B55c_Restore.ipsw">Download</button></li>
+                                            </ul>
+                                        </section>
+                                    </li>
+                                </ul>
+                            </li>
+
+                            <!-- watchOS BETA -->
+                            <li class="table-row">
+                                <section class="col-60">
+                                    <p><span class="platform-title">watchOS</span> 3.1 beta</p>
+                                    <p class="smaller">Install configuration profile directly on your device to receive OTA updates.</p>
+                                </section>
+                                <section class="col-40">
+                                    <ul class="download-details">
+                                        <li class="release-notes"><a href="/go/?id=watchos-3.1-sdk-rn">Release Notes</a></li>
+                                        <li class="build-number">14S452</li>
+                                        <li class="published-date">Sep 21, 2016</li>
+                                        <li class="download"><button class="direct-download" value="/services-account/download?path=/iOS/watchOS_3.1_beta_Configuration_Profile/watchOS_3_beta_Configuration_Profile.mobileconfig">Download</button></li>
+                                    </ul>
+                                </section>
+                            </li>
+
+                            <!-- tvOS BETA -->
+                            <li class="table-row parent-section">
+                                <section class="col-60">
+                                    <p><span class="platform-title">tvOS</span> 10.0.1 beta<span class="violator violator-inline violator-alt">Preferred</span></p>
+                                    <p class="smaller">For Apple TV (4th generation). Apple TV (3rd generation) and earlier are not supported. <br>Install configuration profile directly on your device to receive OTA updates.</p>
+                                </section>
+                                <section class="col-40">
+                                    <ul class="download-details">
+                                        <li class="release-notes"><a href="/go/?id=tvos-10.0.1-sdk-rn">Release Notes</a></li>
+                                        <li class="build-number">14U54</li>
+                                        <li class="published-date">Sep 21, 2016</li>
+                                        <li class="download"><button class="direct-download" value="/services-account/download?path=/tvOS/tvOS_10.0.1_Configuration_Profile/tvOS_10_beta_Configuration_Profile.mobileconfig">Download</button></li>
+                                    </ul>
+                                </section>
+                            </li>
+
+                            <li class="table-row sub-section">
+                                <section class="col-60">
+                                    <p>tvOS Restore Image</p>
+                                    <p class="smaller">Install via iTunes.</p>
+                                </section>
+                                <section class="col-40">
+                                    <ul class="download-details">
+                                            <li class="download"><button class="direct-download" value="http://appldnld.apple.com/tvosseeds/031-59434-20160921-334FA68E-7B80-11E6-9D8B-101F34D2D062/AppleTV5,3_10.0.1_14U54_Restore.ipsw">Download</button></li>
+                                    </ul>
+                                </section>
+                            </li>
+                        </ul>
+                    </section>
+                </div>
+        
+            <!-- BETA TABLE -->
+            <div class="row">
+                <section class="table">
+                    <section class="table-top-sticky">
+                        <section class="table-header row">
+                            <section class="col-60">
+
+                                <!-- Table title -->
+                                <span>Beta Software</span>
+
+                            </section>
+                            <section class="col-40">
+                            <ul class="download-details">
+                                <li class="release-notes">&nbsp;</li>
+                                <li class="build-number">Build</li>
+                                <li class="published-date">Date</li>
+                                <li class="download">&nbsp;</li>
+                            </ul>
+                        </section>
+                        </section>
+                    </section>
+
+                    <ul class="table-rows">
+                        
+                        <!-- Parallax Exporter -->
+                        <li class="table-row">
+                            <section class="col-60">
+                                <p>Parallax Exporter</p>
+                                <p class="smaller">Use the Parallax Exporter plug-in to preview a layered image while working in Adobe Photoshop.</p>
+                            </section>
+                            <section class="col-40">
+                                <ul class="download-details">
+                                    <li class="download"><button class="drop-down">See all</button></li>
+                            </ul>
+                        </section>
+
+                        <ul class="sub-list col-100">
+                            <li class="table-row">
+                                <section class="col-60">
+                                    <p>Parallax Exporter for Mac</p>
+                                </section>
+                                <section class="col-40">
+                                    <ul class="download-details">
+                                        <li class="download"><button class="direct-download" value="https://itunespartner.apple.com/assets/downloads/ParallaxExporter_Apps.zip">Download</button></li>
+                                    </ul>
+                                </section>
+                            </li>
+
+                            <li class="table-row">
+                                <section class="col-60">
+                                    <p>Parallax Exporter for Windows</p>
+                                </section>
+                                <section class="col-40">
+                                    <ul class="download-details">
+                                        <li class="download"><button class="direct-download" value="https://itunespartner.apple.com/assets/downloads/ParallaxExporter_Windows.zip">Download</button></li>
+                                    </ul>
+                                </section>
+                            </li>
+                        </ul>
+                    </li>
+
+                        <!-- Parallax Previewer -->
+                        <li class="table-row">
+                            <section class="col-60">
+                                <p>Parallax Previewer</p>
+                                <p class="smaller">Use Parallax Previewer to preview layered Photoshop files, assemble individual image layers from PNG files and preview the parallax effect, or preview layered images exported by the Parallax Exporter plug-in.</p>
+                            </section>
+                            <section class="col-40">
+                                <ul class="download-details">
+                                    <li class="build-number">1A68</li>
+                                    <li class="published-date">Jan 25, 2016</li>
+                                    <li class="download"><button class="direct-download" value="http://itunespartner.apple.com/assets/downloads/Parallax%20Previewer.dmg">Download</button></li>
+                                </ul>
+                            </section>
+                        </li>
+
+
+                    </ul>
+                </section> <!-- // END BETA TABLE -->
+            </div>
+
+            <!-- Release TABLE -->
+            <div class="row">
+                <section class="table">
+                    <section class="table-top-sticky">
+                        <section class="table-header row">
+                            <section class="col-60">
+
+                                <!-- Table title -->
+                                <span>Release Software</span>
+
+                            </section>
+                            <section class="col-40">
+                            <ul class="download-details">
+                                <li class="release-notes">&nbsp;</li>
+                                <li class="build-number">Build</li>
+                                <li class="published-date">Date</li>
+                                <li class="download">&nbsp;</li>
+                            </ul>
+                        </section>
+                    </section>
+                    </section>
+
+                    <ul class="table-rows">
+
+                        <!-- XCODE -->
+                        <li class="table-row">
+                            <section class="col-60">
+                                <!--<img class="left margin-right-small" src="/assets/elements/icons/xcode-beta/xcode-beta-64x64.png" height="32" width="32" alt=""/>-->
+                                <p><span class="platform-title">Xcode</span> 8</p>
+                                <p class="smaller">Includes iOS, OS X, watchOS, and tvOS SDKs.</p>
+                            </section>
+                            <section class="col-40">
+                                <ul class="download-details">
+                                    <li class="release-notes"><a href="/go/?id=xcode-8-beta-rn">Release Notes</a></li>
+                                    <li class="build-number">8A218a</li>
+                                    <li class="published-date">Sep 13, 2016</li>
+                                    <li class="download"><button class="direct-download" value="https://itunes.apple.com/us/app/xcode/id497799835?ls=1&mt=12">Download</button></li>
+                                </ul>
+                            </section>
+                        </li>
+
+                        <!-- OS X -->
+                        <li class="table-row">
+                            <section class="col-60">
+                                <p><span class="platform-title">macOS Sierra</span>  10.12</p>
+                            </section>
+                            <section class="col-40">
+                                <ul class="download-details">
+                                    <li class="build-number">16A323</li>
+                                    <li class="published-date">Sep 20, 2016</li>
+                                    <li class="download"><button class="direct-download" value="https://itunes.apple.com/us/app/os-x-el-capitan/id1127487414?mt=12">Download</button></li>
+                                </ul>
+                            </section>
+                        </li>
+
+                        <!-- iOS 10 -->
+                        <li class="table-row">
+                            <section class="col-60">
+                                <!--<img class="left margin-right-small" src="/assets/elements/icons/ios-9/ios-9-64x64.png" height="32" width="32" alt=""/>-->
+                                <p><span class="platform-title">iOS</span> 10.0.1</p>
+                            </section>
+                            <section class="col-40">
+                                <ul class="download-details">
+                                    <li class="build-number">14A403</li>
+                                    <li class="published-date">Sep 13, 2016</li>
+                                    <li class="download"><button class="drop-down">See all</button></li>
+                                </ul>
+                            </section>
+
+                            <!-- iOS 10 DOWNLOADS -->
+                            <ul class="sub-list col-100">
+                                <li class="table-row">
+                                    <section class="col-60">
+                                        <p>iPhone SE</p>
+                                        <p class="smaller">Restore image for listed devices.</p>
+                                    </section>
+                                    <section class="col-40">
+                                        <ul class="download-details">
+                                            <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-76426-20160907-170397D2-71FE-11E6-B857-16B934D2D062/iPhoneSE_10.0.1_14A403_Restore.ipsw">Download</button></li>
+                                        </ul>
+                                    </section>
+                                </li>
+                                <li class="table-row">
+                                    <section class="col-60">
+                                        <p>iPhone 6s, iPhone 6</p>
+                                        <p class="smaller">Restore image for listed devices.</p>
+                                    </section>
+                                    <section class="col-40">
+                                        <ul class="download-details">
+                                            <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-76595-20160907-1703F3F8-71FE-11E6-90AF-1DB934D2D062/iPhone_4.7_10.0.1_14A403_Restore.ipsw">Download</button></li>
+                                        </ul>
+                                    </section>
+                                </li>
+                                <li class="table-row">
+                                    <section class="col-60">
+                                        <p>iPhone 6s Plus, iPhone 6 Plus</p>
+                                        <p class="smaller">Restore image for listed devices.</p>
+                                    </section>
+                                    <section class="col-40">
+                                        <ul class="download-details">
+                                            <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-76515-20160907-1706DC08-71FE-11E6-9075-18B934D2D062/iPhone_5.5_10.0.1_14A403_Restore.ipsw">Download</button></li>
+                                        </ul>
+                                    </section>
+                                </li>
+                                <li class="table-row">
+                                    <section class="col-60">
+                                        <p>iPhone 5s</p>
+                                        <p class="smaller">Restore image for listed devices.</p>
+                                    </section>
+                                    <section class="col-40">
+                                        <ul class="download-details">
+                                            <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-76074-20160907-17028284-71FE-11E6-938C-0CB934D2D062/iPhone_4.0_64bit_10.0.1_14A403_Restore.ipsw">Download</button></li>
+                                        </ul>
+                                    </section>
+                                </li>
+                                <li class="table-row">
+                                    <section class="col-60">
+                                        <p>iPhone 5c, iPhone 5</p>
+                                        <p class="smaller">Restore image for listed devices.</p>
+                                    </section>
+                                    <section class="col-40">
+                                        <ul class="download-details">
+                                            <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-76540-20160907-1701C70E-71FE-11E6-B803-1CB934D2D062/iPhone_4.0_32bit_10.0.1_14A403_Restore.ipsw">Download</button></li>
+                                        </ul>
+                                    </section>
+                                </li>
+                                <li class="table-row">
+                                    <section class="col-60">
+                                        <p>9.7‑inch iPad Pro</p>
+                                        <p class="smaller">Restore image for listed devices.</p>
+                                    </section>
+                                    <section class="col-40">
+                                        <ul class="download-details">
+                                            <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-76617-20160907-1707C596-71FE-11E6-BD83-1EB934D2D062/iPadPro_9.7_10.0.1_14A403_Restore.ipsw">Download</button></li>
+                                        </ul>
+                                    </section>
+                                </li>
+                                <li class="table-row">
+                                    <section class="col-60">
+                                        <p>12.9‑inch iPad Pro</p>
+                                        <p class="smaller">Restore image for listed devices.</p>
+                                    </section>
+                                    <section class="col-40">
+                                        <ul class="download-details">
+                                            <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-76619-20160907-17056DD2-71FE-11E6-9239-1FB934D2D062/iPadPro_12.9_10.0.1_14A403_Restore.ipsw">Download</button></li>
+                                        </ul>
+                                    </section>
+                                </li>
+                                <li class="table-row">
+                                    <section class="col-60">
+                                        <p>iPad mini 4, iPad Air 2, iPad mini 3</p>
+                                        <p class="smaller">Restore image for listed devices.</p>
+                                    </section>
+                                    <section class="col-40">
+                                        <ul class="download-details">
+                                            <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-76179-20160907-1701E9AA-71FE-11E6-AC72-0EB934D2D062/iPad_64bit_TouchID_10.0.1_14A403_Restore.ipsw">Download</button></li>
+                                        </ul>
+                                    </section>
+                                </li>
+                                <li class="table-row">
+                                    <section class="col-60">
+                                        <p>iPad Air, iPad mini 2</p>
+                                        <p class="smaller">Restore image for listed devices.</p>
+                                    </section>
+                                    <section class="col-40">
+                                        <ul class="download-details">
+                                            <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-76658-20160907-1706E0F4-71FE-11E6-84E4-20B934D2D062/iPad_64bit_10.0.1_14A403_Restore.ipsw">Download</button></li>
+                                        </ul>
+                                    </section>
+                                </li>
+                                <li class="table-row">
+                                    <section class="col-60">
+                                        <p>iPad <span class="lighter">(4th generation Model)</span></p>
+                                        <p class="smaller">Restore image for listed devices.</p>
+                                    </section>
+                                    <section class="col-40">
+                                        <ul class="download-details">
+                                            <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-76396-20160907-1702BF88-71FE-11E6-84AD-14B934D2D062/iPad_32bit_10.0.1_14A403_Restore.ipsw">Download</button></li>
+                                        </ul>
+                                    </section>
+                                </li>
+                                <li class="table-row">
+                                    <section class="col-60">
+                                        <p>iPod touch <span class="lighter">(6th generation)</span></p>
+                                        <p class="smaller">Restore image for listed devices.</p>
+                                    </section>
+                                    <section class="col-40">
+                                        <ul class="download-details">
+                                            <li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-76322-20160907-1706F350-71FE-11E6-BE48-12B934D2D062/iPodtouch_10.0.1_14A403_Restore.ipsw">Download</button></li>
+                                        </ul>
+                                    </section>
+                                </li>
+                            </ul>
+
+                        </li>
+
+                        <!-- tvOS -->
+                        <li class="table-row">
+                            <section class="col-60">
+                                <p><span class="platform-title">tvOS</span> 10</p>
+                            </section>
+                            <section class="col-40">
+                                <ul class="download-details">
+                                    <li class="build-number">14T330</li>
+                                    <li class="published-date">Sep 13, 2016</li>
+                                    <li class="download"><button class="direct-download" value="http://appldnld.apple.com/tvos10.0/031-76856-20160916-B770B2D0-722C-11E6-8D32-1C4033D2D062/AppleTV5,3_10.0_14T330_Restore.ipsw">Download</button></li>
+                                </ul>
+                            </section>
+                        </li>
+
+                        <!-- OS X SERVER -->
+                        <li class="table-row">
+                            <section class="col-60">
+                                <p><span class="platform-title">macOS Server</span> 5.2</p>
+                                <p class="smaller hidden">App Store Redemption Code: <span data-promo-id="RGG4THX5SU"></span></p>
+                            </section>
+                            <section class="col-40">
+                                <ul class="download-details">
+                                    <li class="build-number">16S1195</li>
+                                    <li class="published-date">Sep 20, 2016</li>
+                                    <li class="download"><button data-promo-id="RGG4THX5SU">Download</button></li>
+                                </ul>
+                            </section>
+                        </li>
+
+                    </ul>
+                </section> <!-- // END RELEASE TABLE -->
+            </div>
+
+
+
+            <div class="row">
+                <div class="col-100 no-padding-bottom">
+                    <h5>Installation Guides and Acknowledgements</h5>
+                </div>
+            </div>
+            <div class="row divider-top">
+                <div class="col-50 no-padding-bottom">
+                    <ul class="links small">
+                        <h6>iOS</h6>
+                        <li class="library"><a href="/go/?id=install-ios-beta">iOS beta Software Installation Guide</a></li>
+                        <li class="library"><a href="/go/?id=ios-10.0-acknowledgements">Swift Playgrounds Acknowledgements</a></li>
+
+                        <h6>watchOS</h6>
+                        <li class="library"><a href="/go/?id=install-watchos-beta">watchOS beta Software Installation Guide</a></li>
+                    </ul>
+                </div>
+                <div class="col-50 no-padding-bottom">
+                    <ul class="links small">
+                        <h6>tvOS</h6>
+                        <li class="library"><a href="/go/?id=install-tvos-beta">tvOS beta Software Installation Guide</a></li>
+                    </ul>
+                    <ul class="links small">
+                        <h6>Additional Guides</h6>
+                        <li class="library"><a href="/library/prerelease/content/technotes/tn2249/_index.html">Testing your app on beta OS releases</a></li>
+                    </ul>
+                </div>
+
+            </div>
+        </section>
+
+        
+
+
+    </main>
+
+    <div class="bg-light">
+        <aside class="grid">
+            <section id="router" class="router">
+                <a href="/download/more/" class="block row">
+                    <span class="col-100 text-center">
+                        <span class="two-lines">
+                            <h4>
+                                <small>Don't see what you're looking for?</small>
+                                See more downloads
+                            </h4>
+                        </span>
+                    </span>
+                </a>
+            </section>
+        </aside>
+    </div>
+
+
+    <section id="globalfooter-wrapper">
+    <footer id="globalfooter" role="contentinfo">
+        <nav class="footer-breadory">
+            <a href="/" class="home breadcrumbs-home"><span aria-hidden="true"></span><span class="breadcrumbs-home-label">Developer</span></a>
+            <section class="breadcrumbs">
+                <ol class="breadcrumbs-list">
+                    <li>Download</li>
+                </ol>
+            </section>
+            <div id="directorynav" class="directorynav">
+    <div id="dn-cola" class="column">
+        <h3><a href="/discover/">Discover</a></h3>
+        <ul>
+            <li><a href="/macos/">macOS</a></li>
+            <li><a href="/ios/">iOS</a></li>
+            <li><a href="/watchos/">watchOS</a></li>
+            <li><a href="/tvos/">tvOS</a></li>
+            <li><a href="/programs/">Developer Program</a></li>
+            <li><a href="/enterprise/">Enterprise</a></li>
+            <li><a href="/education/">Education</a></li>
+        </ul>
+
+    </div>
+    <div id="dn-colb" class="column">
+        <h3><a href="/design/">Design</a></h3>
+        <ul>
+            <li><a href="/accessibility/">Accessibility</a></li>
+            <li><a href="/cases/">Accessories</a></li>
+            <li><a href="/design/adaptivity/">Adaptivity</a></li>
+            <li><a href="/design/awards/">Apple Design Awards</a></li>
+            <li><a href="/fonts/">Fonts</a></li>
+            <li><a href="/videos/design/">Design Videos</a></li>
+            <li><a href="/app-store/marketing/guidelines/">Marketing Guidelines</a></li>
+        </ul>
+    </div>
+    <div id="dn-colc" class="column">
+        <h3><a href="/develop/">Develop</a></h3>
+        <ul>
+            <li><a href="/xcode/">Xcode</a></li>
+            <li><a href="/swift/">Swift</a></li>
+            <li><a href="/download/">Downloads</a></li>
+            <li><a href="/reference/">API Reference</a></li>
+            <li><a href="/library/prerelease/content/navigation/">Guides</a></li>
+            <li><a href="/library/prerelease/content/navigation/#section=Resource%20Types&topic=Sample%20Code">Sample Code</a></li>
+            <li><a href="/videos/">Videos</a></li>
+        </ul>
+
+    </div>
+    <div id="dn-cold" class="column">
+        <h3><a href="/distribute/">Distribute</a></h3>
+        <ul>
+            <li><a href="/app-store/">App Store</a></li>
+            <li><a href="/app-store/review/">App Review</a></li>
+            <li><a href="https://itunesconnect.apple.com/">iTunes Connect</a></li>
+            <li><a href="/testflight/">TestFlight</a></li>
+            <li><a href="/enterprise/">Enterprise</a></li>
+            <li><a href="/safari/extensions/">Safari Extensions</a></li>
+        </ul>
+    </div>
+    <div id="dn-cole" class="column">
+        <h3><a href="/support/">Support</a></h3>
+        <ul>
+            <li><a href="https://forums.developer.apple.com">Developer Forums</a></li>
+            <li><a href="/contact/">Contact Us</a></li>
+            <li><a href="/bug-reporting/">Bug Reporting</a></li>
+            <li><a href="/terms/">License Agreements</a></li>
+            <li><a href="/system-status/">System Status</a></li>
+        </ul>
+    </div>
+</div>
+
+        </nav>
+        <div class="ac-gf-footer-legal">
+  <div class="ac-gf-footer-news"> To receive the latest developer news, visit and subscribe to our <a href="/news/">News and Updates</a>. </div>
+  <div class="ac-gf-footer-legal-copyright">Copyright © 2016 Apple Inc. All rights reserved.</div>
+  <div class="ac-gf-footer-legal-links">
+    <a href="https://www.apple.com/legal/internet-services/terms/site.html" class="first">Terms of Use</a>
+    <a href="https://www.apple.com/privacy/privacy-policy/">Privacy Policy</a>
+    <a href="/bug-reporting/">Report Bugs</a>
+    <a href="/contact/submit/?subject=website-feedback">Feedback</a>
+  </div>
+</div>
+
+    </footer>
+</section>
+
+</body>
+</html>

--- a/spec/prerelease_spec.rb
+++ b/spec/prerelease_spec.rb
@@ -90,5 +90,12 @@ module XcodeInstall
       prereleases.count.should == 1
       prereleases.first.should == Xcode.new_prerelease('8 beta 2', '/devcenter/download.action?path=/Developer_Tools/Xcode_8_beta_2/Xcode_8_beta_2.xip', nil)
     end
+
+    it 'can parse prereleases from 20160922' do
+      prereleases = parse_prereleases('20160922')
+
+      prereleases.count.should == 1
+      prereleases.first.should == Xcode.new('8.1 beta', '/services-account/download?path=/Developer_Tools/Xcode_8.1_beta/Xcode_8.1_beta.xip', '/go/?id=xcode-8.1-beta-rn')
+    end
   end
 end


### PR DESCRIPTION
I added this because as of the first Xcode 8.1 beta (released Sept. 21), it was parsing the version as `8.1 beta requires OS X 10.11.5 or later.`