### PR TITLE
Fix for `install-cli-tools` command on Sierra

### DIFF
--- a/lib/xcode/install/cli.rb
+++ b/lib/xcode/install/cli.rb
@@ -19,7 +19,7 @@ module XcodeInstall
         FileUtils.touch(cli_placeholder_file)
         # find the CLI Tools update
         product = `softwareupdate -l | grep "\*.*Command Line" | head -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n'`
-        `softwareupdate -i "#{product}" -v`
+        `softwareupdate --verbose -i "#{product}"`
         FileUtils.rm(cli_placeholder_file)
       end
     end


### PR DESCRIPTION
Apple removed the `-v` shorthand verbose option for `softwareupdate` in Sierra causing the `install-cli-tools` option to fail on install. The `--verbose` option still works, and does for prior OS versions as well.