### PR TITLE
Use newer CDN for sims for versions 8.1 and up

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -468,7 +468,13 @@ HELP
     end
 
     def downloadable_index_url
-      @downloadable_index_url ||= "https://devimages.apple.com.edgekey.net/downloads/xcode/simulators/index-#{bundle_version}-#{uuid}.dvtdownloadableindex"
+      @downloadable_index_url ||= begin
+        if Gem::Version.new(version) >= Gem::Version.new('8.1')
+          "https://devimages-cdn.apple.com/downloads/xcode/simulators/index-#{bundle_version}-#{uuid}.dvtdownloadableindex"
+        else
+          "https://devimages.apple.com.edgekey.net/downloads/xcode/simulators/index-#{bundle_version}-#{uuid}.dvtdownloadableindex"
+        end
+      end
     end
 
     def approve_license


### PR DESCRIPTION
8.1 seems to use a new CDN base URL for the simulators and docsets. I used Charles and `strings /Applications/Xcode.app/Contents/PlugIns/IDEiOSSupportCore.ideplugin/Contents/MacOS/IDEiOSSupportCore | grep http` to see which CDNs were being used. This should address #180.