### PR TITLE
Replace spaceship with fastlane dependency for mono gem

### DIFF
--- a/xcode-install.gemspec
+++ b/xcode-install.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'claide', '>= 0.9.1', '< 1.1.0'
-  spec.add_dependency 'spaceship', '>= 0.25.1', '< 1.0.0'
+  spec.add_dependency 'fastlane', '>= 2.0.5', '< 3.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/xcode-install.gemspec
+++ b/xcode-install.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'claide', '>= 0.9.1', '< 1.1.0'
-  spec.add_dependency 'fastlane', '>= 2.0.5', '< 3.0.0'
+  spec.add_dependency 'fastlane', '>= 2.1.0', '< 3.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
This is required as the spaceship gem is no longer updated

Related PR https://github.com/fastlane/fastlane/pull/7554