### PR TITLE
Fix issue trying to process nil and empty strings version strings

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -158,9 +158,10 @@ HELP
     end
 
     def list_current
-      stable_majors = list_versions.reject { |v| /beta/i =~ v }.map { |v| v.split('.')[0] }.map { |v| v.split(' ')[0] }
+      safe_list_versions = list_versions.reject { |v| v.nil? || v.empty? }
+      stable_majors = safe_list_versions.reject { |v| /beta/i =~ v }.map { |v| v.split('.')[0] }.map { |v| v.split(' ')[0] }
       latest_stable_major = stable_majors.select { |v| v.length == 1 }.uniq.sort.last.to_i
-      current_versions = list_versions.select { |v| v.split('.')[0].to_i >= latest_stable_major }.sort
+      current_versions = safe_list_versions.select { |v| v.split('.')[0].to_i >= latest_stable_major }.sort
       list_annotated(current_versions)
     end
 

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -40,6 +40,11 @@ module XcodeInstall
         fake_xcodes '5', '6.1', '6', '6.4 beta', '7 beta'
         installer.list_current.should == "6\n6.1\n6.4 beta\n7 beta"
       end
+
+      it 'shows removes spurious versions from the list' do
+        fake_xcodes '8.1', '8.2', '', nil
+        installer.list_current.should == "8.1\n8.2"
+      end
     end
   end
 end


### PR DESCRIPTION
After installing version 2.1.0 today, I kept getting an issue running `xcversion list`, where it seemed to be trying to process incorrectly formatted version strings. This change attempts to add a test to expose the issue and implement a fix.

I'm running macOS Sierra 10.12.2 and ruby 2.4.

eg. 

```
$ xcversion list
/Users/sgleadow/.gem/ruby/2.4.0/gems/xcode-install-2.0.9/lib/xcode/install.rb:161:in `block in list_current': undefined method `split' for nil:NilClass (NoMethodError)
	from /Users/sgleadow/.gem/ruby/2.4.0/gems/xcode-install-2.0.9/lib/xcode/install.rb:161:in `map'
	from /Users/sgleadow/.gem/ruby/2.4.0/gems/xcode-install-2.0.9/lib/xcode/install.rb:161:in `list_current'
	from /Users/sgleadow/.gem/ruby/2.4.0/gems/xcode-install-2.0.9/lib/xcode/install/list.rb:22:in `run'
	from /Users/sgleadow/.gem/ruby/2.4.0/gems/claide-1.0.1/lib/claide/command.rb:334:in `run'
	from /Users/sgleadow/.gem/ruby/2.4.0/gems/xcode-install-2.0.9/bin/xcversion:12:in `<top (required)>'
	from /Users/sgleadow/.gem/ruby/2.4.0/bin/xcversion:22:in `load'
	from /Users/sgleadow/.gem/ruby/2.4.0/bin/xcversion:22:in `<main>'
```

For closer inspection, I printed out the initial `list_versions` that is processed within _install.rb:161_, and it appears to have an empty string as one of the versions returned (I guess a change on Apple's part?):

```
> list_versions
["4.3.2 for Lion", "4.5", "4.3.3 for Lion", "4.5.1", "4.3 for Lion", "4.3.1 for Lion", "4.4.1", "4.4", "4.6.1", "4.6", "4.5.2", "5", "5.0.1", "5.0.2", "4.6.3", "4.6.2", "6.1.1", "6.1", "6.0.1", "5.1.1", "5.1", "6.3.2", "7.1.1", "7", "7.2", "6.3", "7.1", "6.3.1", "6.2", "6.4", "7.0.1", "7.3.1", "8.1", "8.2", "8", "7.3", "8.2.1", "7.2.1", ""]
```

I've added a step to string out both `nil` and `empty` strings before processing, to protect against this happening in the future. After this, the `list` command worked again as usual.

```
$ xcversion list
8
8.1
8.2
8.2.1 (installed)
```