### PR TITLE
Fix edge cases with incompatible Xcode versions

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -259,12 +259,8 @@ HELP
     end
 
     def installed
-      unless (`mdutil -s /` =~ /disabled/).nil?
-        $stderr.puts 'Please enable Spotlight indexing for /Applications.'
-        exit(1)
-      end
-
-      `mdfind "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'" 2>/dev/null`.split("\n")
+      app_xml = `system_profiler -detailLevel full SPApplicationsDataType -xml`
+      app_xml.scan(/<string>(.*?Xcode[-\d\.]*app)<\/string>/).flatten
     end
 
     def parse_seedlist(seedlist)

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -488,13 +488,11 @@ HELP
     end
 
     def available_simulators
-      begin
-        @available_simulators ||= JSON.parse(`curl -Ls #{downloadable_index_url} | plutil -convert json -o - -`)['downloadables'].map do |downloadable|
-          Simulator.new(downloadable)
-        end
-      rescue JSON::ParserError
-        return []
+      @available_simulators ||= JSON.parse(`curl -Ls #{downloadable_index_url} | plutil -convert json -o - -`)['downloadables'].map do |downloadable|
+        Simulator.new(downloadable)
       end
+    rescue JSON::ParserError
+      return []
     end
 
     def install_components

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -259,8 +259,12 @@ HELP
     end
 
     def installed
-      app_xml = `system_profiler -detailLevel full SPApplicationsDataType -xml`
-      app_xml.scan(/<string>(.*?Xcode[-\d\.]*app)<\/string>/).flatten
+      unless (`mdutil -s /` =~ /disabled/).nil?
+        $stderr.puts 'Please enable Spotlight indexing for /Applications.'
+        exit(1)
+      end
+
+      `mdfind "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'" 2>/dev/null`.split("\n")
     end
 
     def parse_seedlist(seedlist)

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -511,7 +511,7 @@ HELP
 
     def fetch_version
       output = `DEVELOPER_DIR='' "#{@path}/Contents/Developer/usr/bin/xcodebuild" -version`
-      return '0.0' if output.nil? # ¯\_(ツ)_/¯
+      return '0.0' if output.nil? || output.empty? # ¯\_(ツ)_/¯
       output.split("\n").first.split(' ')[1]
     end
   end

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -484,8 +484,12 @@ HELP
     end
 
     def available_simulators
-      @available_simulators ||= JSON.parse(`curl -Ls #{downloadable_index_url} | plutil -convert json -o - -`)['downloadables'].map do |downloadable|
-        Simulator.new(downloadable)
+      begin
+        @available_simulators ||= JSON.parse(`curl -Ls #{downloadable_index_url} | plutil -convert json -o - -`)['downloadables'].map do |downloadable|
+          Simulator.new(downloadable)
+        end
+      rescue JSON::ParserError
+        return []
       end
     end
 


### PR DESCRIPTION
This started as the fixes from #204 but that sort of fell apart. However, to test those changes I installed Xcode 8.3 but was running macOS 10.11. The Xcode app downloaded and worked but `LSMinimumSystemVersion` is 10.12 so some weird edge cases started cropping up. The technical details are in the commit messages.

To illustrate the problem, prior to these changes I saw:

```
$ ./bin/xcversion installed
Executable requires at least macOS 10.12, but is being run on macOS 10.11.6, and so is exiting./Users/justinscott/dev/xcode-install/lib/xcode/install.rb:515:i
n `fetch_version': undefined method `split' for nil:NilClass (NoMethodError)
        from /Users/justinscott/dev/xcode-install/lib/xcode/install.rb:460:in `version'
        from /Users/justinscott/dev/xcode-install/lib/xcode/install.rb:70:in `block in installed_versions'
        from /Users/justinscott/dev/xcode-install/lib/xcode/install.rb:69:in `sort'
        from /Users/justinscott/dev/xcode-install/lib/xcode/install.rb:69:in `installed_versions'
        from /Users/justinscott/dev/xcode-install/lib/xcode/install/installed.rb:18:in `run'
        from /usr/local/lib/ruby/gems/2.3.0/gems/claide-1.0.1/lib/claide/command.rb:334:in `run'
        from ./bin/xcversion:12:in `<main>'
```

and with them I see:

```
$ ./bin/xcversion installed
Executable requires at least macOS 10.12, but is being run on macOS 10.11.6, and so is exiting.0.0      (/Applications/Xcode-8.3.app)
8.1     (/Users/justinscott/Downloads/Xcode.app)
8.2.1   (/Applications/Xcode.app)
```

It's probably worth squashing this all into one commit on merge. There's no need to have a history of the Spotlight replacement stuff.