### PR TITLE
Cache file write by binary mode

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -251,7 +251,7 @@ HELP
       names = @xcodes.map(&:name)
       @xcodes += prereleases.reject { |pre| names.include?(pre.name) }
 
-      File.open(LIST_FILE, 'w') do |f|
+      File.open(LIST_FILE, 'wb') do |f|
         f << Marshal.dump(xcodes)
       end
 


### PR DESCRIPTION
I did not work xcode-install on Rails, it is a problem caused by encoding.
We should not consider about encoding in Marshal.
So we should use binary mode in Marshal.

```
irb(main):011:0> XcodeInstall::Installer.new.list
Encoding::UndefinedConversionError: "\xDC" from ASCII-8BIT to UTF-8
	from /Users/junki.kaneko/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/xcode-install-1.4.0/lib/xcode/install.rb:229:in `write'
	from /Users/junki.kaneko/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/xcode-install-1.4.0/lib/xcode/install.rb:229:in `<<'
	from /Users/junki.kaneko/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/xcode-install-1.4.0/lib/xcode/install.rb:229:in `block in fetch_seedlist'
	from /Users/junki.kaneko/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/xcode-install-1.4.0/lib/xcode/install.rb:228:in `open'
	from /Users/junki.kaneko/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/xcode-install-1.4.0/lib/xcode/install.rb:228:in `fetch_seedlist'
	from /Users/junki.kaneko/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/xcode-install-1.4.0/lib/xcode/install.rb:277:in `seedlist'
	from /Users/junki.kaneko/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/xcode-install-1.4.0/lib/xcode/install.rb:257:in `list_versions'
	from /Users/junki.kaneko/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/xcode-install-1.4.0/lib/xcode/install.rb:143:in `list'
	from (irb):11
	from /Users/junki.kaneko/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/railties-5.0.1/lib/rails/commands/console.rb:65:in `start'
	from /Users/junki.kaneko/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/railties-5.0.1/lib/rails/commands/console_helper.rb:9:in `start'
	from /Users/junki.kaneko/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/railties-5.0.1/lib/rails/commands/commands_tasks.rb:78:in `console'
	from /Users/junki.kaneko/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/railties-5.0.1/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
	from /Users/junki.kaneko/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/railties-5.0.1/lib/rails/commands.rb:18:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
```
