### PR TITLE
use new -runFirstLaunch flag for postinstalls >= 9

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -496,8 +496,14 @@ HELP
     end
 
     def install_components
-      Dir.glob("#{@path}/Contents/Resources/Packages/*.pkg").each do |pkg|
-        `sudo installer -pkg #{pkg} -target /`
+      # starting with Xcode 9, we have `xcodebuild -runFirstLaunch` available to do package
+      # postinstalls using a documented option
+      if Gem::Version.new(@version) >= Gem::Version.new('9')
+        `sudo #{@path}/Contents/Developer/usr/bin/xcodebuild -runFirstLaunch`
+      else
+        Dir.glob("#{@path}/Contents/Resources/Packages/*.pkg").each do |pkg|
+          `sudo installer -pkg #{pkg} -target /`
+        end
       end
       osx_build_version = `sw_vers -buildVersion`.chomp
       tools_version = `/usr/libexec/PlistBuddy -c "Print :ProductBuildVersion" "#{@path}/Contents/version.plist"`.chomp


### PR DESCRIPTION
Xcode 9 has a new documented feature for `xcodebuild`, `-runFirstLaunch`, to install all the additional packages. The old manual per-package method using `installer` still works, but it seems logical to use an Apple-supported command if it exists.

`xcodebuild -runFirstLaunch` only does the package installs, so the other work being done to accept the EULA, etc. has to still be done as is done now.

If you run this command interactively, you get a simple progress output and you can see the package installs happen in `/var/log/install.log`:

```
sudo /Applications/Xcode-9.app/Contents/Developer/usr/bin/xcodebuild -runFirstLaunch
Install Started
4
11
14
15
16
17
18
19
20
21
22
23
24
25
76
79
87
88
89
90
91
92
93
94
95
96
97
Install Succeeded
```

Also note that the manpage for Xcode 9's `xcodebuild` says this about this command:

`install packages and agree to the license`

.. but if you run this without the license being agreed to, it prompts you interactively accept the license, so something in either the behaviour or the manpage is wrong in this beta.