### PR TITLE
Fix broken deletion if spctl fails on the Xcode app bundle

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -113,7 +113,7 @@ HELP
       end
 
       unless verify_integrity(xcode_path)
-        `sudo rm -f #{xcode_path}`
+        `sudo rm -rf #{xcode_path}`
         return
       end
 


### PR DESCRIPTION
Just noticed this one when I had an `spctl` verify fail. This should be recursive since the Xcode path is a full app bundle.