### PR TITLE
Add --no-progress flag for simulator install

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -379,13 +379,13 @@ HELP
       end
     end
 
-    def download
-      result = Curl.new.fetch(source, CACHE_DIR)
+    def download(progress)
+      result = Curl.new.fetch(source, CACHE_DIR, nil, nil, progress)
       result ? dmg_path : nil
     end
 
-    def install
-      download unless dmg_path.exist?
+    def install(progress)
+      download(progress) unless dmg_path.exist?
       prepare_package unless pkg_path.exist?
       puts "Please authenticate to install #{name}..."
       `sudo installer -pkg #{pkg_path} -target /`

--- a/lib/xcode/install/simulators.rb
+++ b/lib/xcode/install/simulators.rb
@@ -7,12 +7,14 @@ module XcodeInstall
       self.summary = 'List or install iOS simulators.'
 
       def self.options
-        [['--install=name', 'Install simulator beginning with name, e.g. \'iOS 8.4\', \'tvOS 9.0\'.']].concat(super)
+        [['--install=name', 'Install simulator beginning with name, e.g. \'iOS 8.4\', \'tvOS 9.0\'.'],
+         ['--no-progress', 'Don’t show download progress.']].concat(super)
       end
 
       def initialize(argv)
         @installed_xcodes = Installer.new.installed_versions
         @install = argv.option('install')
+        @progress = argv.flag?('progress', true)
         super
       end
 
@@ -36,7 +38,7 @@ module XcodeInstall
         simulator = filtered_simulators.first
         fail Informative, "#{simulator.name} is already installed." if simulator.installed?
         puts "Installing #{simulator.name} for Xcode #{simulator.xcode.bundle_version}..."
-        simulator.install
+        simulator.install(@progress)
       else
         puts "[!] More than one simulator matching #{@install} was found. Please specify the full version.".ansi.red
         filtered_simulators.each do |candidate|


### PR DESCRIPTION
xcode-install has a `--no-progress` flag that you can pass when
installing a version of xcode, but no such flag exists when installing a
simulator.

This changes adds a --no-progress flag that mirrors the implementation
from installing xcodes.