### PR TITLE
Enable curl built-in retries for transient errors

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -20,8 +20,9 @@ module XcodeInstall
       output ||= File.basename(uri.path)
       output = (Pathname.new(directory) + Pathname.new(output)) if directory
 
+      retry_options = ['--retry', '3']
       progress = progress ? '--progress-bar' : '--silent'
-      command = ['curl', *options, '--location', '--continue-at', '-', progress, '--output', output, url].map(&:to_s)
+      command = ['curl', *options, *retry_options, '--location', '--continue-at', '-', progress, '--output', output, url].map(&:to_s)
       io = IO.popen(command)
       io.each { |line| puts line }
       io.close


### PR DESCRIPTION
The goal here is to make downloading more robust in the face of network issues. Xcode and the simulators are getting larger with each release, which makes the chance of download errors higher.

Somewhat addresses #210, but not the specific `18` return code.

From `man curl`

```
       --retry <num>
              If a transient error is returned when curl tries  to  perform  a
              transfer,  it  will retry this number of times before giving up.
              Setting the number to 0 makes curl do no retries (which  is  the
              default).  Transient  error  means either: a timeout, an FTP 4xx
              response code or an HTTP 5xx response code.

              When curl is about to retry a transfer, it will first  wait  one
              second  and  then for all forthcoming retries it will double the
              waiting time until it reaches 10 minutes which then will be  the
              delay  between  the rest of the retries.  By using --retry-delay
              you  disable  this  exponential  backoff  algorithm.  See   also
              --retry-max-time to limit the total time allowed for retries.

              If this option is used several times, the last one will be used.

              Added in 7.12.3.
```