### PR TITLE
prevent release notes from launching in browser

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -142,7 +142,7 @@ HELP
       FileUtils.rm_f(dmg_path) if clean
     end
 
-    def install_version(version, switch = true, clean = true, install = true, progress = true, url = nil)
+    def install_version(version, switch = true, clean = true, install = true, progress = true, url = nil, show_release_notes = true)
       dmg_path = get_dmg(version, progress, url)
       fail Informative, "Failed to download Xcode #{version}." if dmg_path.nil?
 
@@ -152,7 +152,7 @@ HELP
         puts "Downloaded Xcode #{version} to '#{dmg_path}'"
       end
 
-      open_release_notes_url(version) unless url
+      open_release_notes_url(version) if show_release_notes && !url
     end
 
     def open_release_notes_url(version)

--- a/lib/xcode/install/install.rb
+++ b/lib/xcode/install/install.rb
@@ -16,7 +16,8 @@ module XcodeInstall
          ['--no-switch', 'Don’t switch to this version after installation'],
          ['--no-install', 'Only download DMG, but do not install it.'],
          ['--no-progress', 'Don’t show download progress.'],
-         ['--no-clean', 'Don’t delete DMG after installation.']].concat(super)
+         ['--no-clean', 'Don’t delete DMG after installation.'],
+         ['--no-show-release-notes', 'Don’t open release notes in browser after installation.']].concat(super)
       end
 
       def initialize(argv)
@@ -28,6 +29,7 @@ module XcodeInstall
         @should_install = argv.flag?('install', true)
         @should_switch = argv.flag?('switch', true)
         @progress = argv.flag?('progress', true)
+        @show_release_notes = argv.flag?('show-release-notes', true)
         super
       end
 
@@ -42,7 +44,7 @@ module XcodeInstall
 
       def run
         @installer.install_version(@version, @should_switch, @should_clean, @should_install,
-                                   @progress, @url)
+                                   @progress, @url, @show_release_notes)
       end
     end
   end


### PR DESCRIPTION
with `--no-show-release-notes` flag for `install` command.