### PR TITLE
Add Symlink Option To Select Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ xcversion list
 6.3
 ```
 
-Already installed versions are marked with `(installed)`.  
+Already installed versions are marked with `(installed)`.
 (Use `$ xcversion installed` to only list installed Xcodes with their path).
 
 To update the list of available versions, run:
@@ -70,7 +70,7 @@ Xcode 8
 Build version 6D570
 ```
 
-This will download and install that version of Xcode. Then you can start it from `/Applications` as usual.  
+This will download and install that version of Xcode. Then you can start it from `/Applications` as usual.
 The new version will also be automatically selected for CLI commands (see below).
 
 #### GMs and beta versions
@@ -95,6 +95,11 @@ $ xcversion selected
 To select a version as active, run
 ```
 $ xcversion select 8
+```
+
+To select a version as active and change the symlink at `/Applications/Xcode`, run
+```
+$ xcversion select 8 --symlink
 ```
 
 ### Command Line Tools

--- a/lib/xcode/install/select.rb
+++ b/lib/xcode/install/select.rb
@@ -8,9 +8,14 @@ module XcodeInstall
         CLAide::Argument.new('VERSION', :true)
       ]
 
+      def self.options
+        [['--symlink', 'Update symlink in /Applications with selected Xcode']].concat(super)
+      end
+
       def initialize(argv)
         @installer = Installer.new
         @version = argv.shift_argument
+        @should_symlink = argv.flag?('symlink', false)
         super
       end
 
@@ -24,6 +29,7 @@ module XcodeInstall
       def run
         xcode = @installer.installed_versions.detect { |v| v.version == @version }
         `sudo xcode-select --switch #{xcode.path}`
+        @installer.symlink xcode.version if @should_symlink
       end
     end
   end


### PR DESCRIPTION
Added a Symlink flag to the `select` command that will update the symlink at `\Applications\Xcode` with the given version. If the flag is not passed, then the symlink will remain unchanged.
