### PR TITLE
Update & improve xcode-install to work with fastlane.ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ $ gem install xcode-install
 $ xcversion install 6.3
 ```
 
+This tool uses the [Downloads for Apple Developer](https://developer.apple.com/download/more/) page.
+
 ## Installation
 
 ```

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -41,7 +41,6 @@ module XcodeInstall
       FileUtils.rm_f(COOKIES_PATH)
     end
   end
-
   class Installer
     attr_reader :xcodes
 
@@ -78,7 +77,7 @@ module XcodeInstall
         return current_seed if current_seed.version == Gem::Version.new(version)
         return current_seed if current_seed.name == version
       end
-      return nil
+      nil
     end
 
     def exist?(version)

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -93,7 +93,6 @@ module XcodeInstall
     def seedlist
       @xcodes = Marshal.load(File.read(LIST_FILE)) if LIST_FILE.exist? && xcodes.nil?
       all_xcodes = (xcodes || fetch_seedlist)
-      
 
       # We have to set the `installed` value here, as we might still use
       # the cached list of available Xcode versions, but have a new Xcode
@@ -103,7 +102,7 @@ module XcodeInstall
         current_xcode.installed = cached_installed_versions.include?(current_xcode.version)
       end
 
-      return all_xcodes.sort do |a, b|
+      all_xcodes.sort do |a, b|
         a.version <=> b.version
       end
     end
@@ -548,15 +547,15 @@ HELP
 
   # A version of Xcode we fetched from the Apple Developer Portal
   # we can download & install.
-  # 
+  #
   # Sample object:
-   # <XcodeInstall::Xcode:0x007fa1d451c390
-   #    @date_modified=2015,
-   #    @name="6.4",
-   #    @path="/Developer_Tools/Xcode_6.4/Xcode_6.4.dmg",
-   #    @url=
-   #     "https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_6.4/Xcode_6.4.dmg",
-   #    @version=Gem::Version.new("6.4")>,
+  # <XcodeInstall::Xcode:0x007fa1d451c390
+  #    @date_modified=2015,
+  #    @name="6.4",
+  #    @path="/Developer_Tools/Xcode_6.4/Xcode_6.4.dmg",
+  #    @url=
+  #     "https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_6.4/Xcode_6.4.dmg",
+  #    @version=Gem::Version.new("6.4")>,
   class Xcode
     attr_reader :date_modified
 
@@ -594,7 +593,7 @@ HELP
     end
 
     def installed?
-      return self.installed
+      installed
     end
 
     def to_s

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -186,7 +186,7 @@ HELP
       fail Informative, "Failed to download Xcode #{version}." if dmg_path.nil?
 
       if install
-        install_dmg(dmg_path, "-#{version.split(' ')[0]}", switch, clean)
+        install_dmg(dmg_path, "-#{version.to_s.split(' ')[0]}", switch, clean)
       else
         puts "Downloaded Xcode #{version} to '#{dmg_path}'"
       end

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -83,7 +83,8 @@ module XcodeInstall
     end
 
     def exist?(version)
-      !find_xcode_version(version).nil?
+      return true if find_xcode_version(version)
+      false
     end
 
     def installed?(version)

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -41,6 +41,8 @@ module XcodeInstall
       FileUtils.rm_f(COOKIES_PATH)
     end
   end
+
+  # rubocop:disable Metrics/ClassLength
   class Installer
     attr_reader :xcodes
 

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -102,9 +102,7 @@ module XcodeInstall
         current_xcode.installed = cached_installed_versions.include?(current_xcode.version)
       end
 
-      all_xcodes.sort do |a, b|
-        a.version <=> b.version
-      end
+      all_xcodes.sort_by(&:version)
     end
 
     def install_dmg(dmg_path, suffix = '', switch = true, clean = true)
@@ -569,6 +567,8 @@ HELP
     # Accessor since it's set by the `Installer`
     attr_accessor :installed
 
+    alias installed? installed
+
     def initialize(json, url = nil, release_notes_url = nil)
       if url.nil?
         @date_modified = json['dateModified'].to_i
@@ -590,10 +590,6 @@ HELP
       rescue
         @version = Installer::MINIMUM_VERSION
       end
-    end
-
-    def installed?
-      installed
     end
 
     def to_s

--- a/xcode-install.gemspec
+++ b/xcode-install.gemspec
@@ -21,7 +21,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+
+  # CLI parsing
   spec.add_dependency 'claide', '>= 0.9.1', '< 1.1.0'
+
+  # contains spaceship, which is used for auth and dev portal interactions
   spec.add_dependency 'fastlane', '>= 2.1.0', '< 3.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.7'

--- a/xcode-install.gemspec
+++ b/xcode-install.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-
   # CLI parsing
   spec.add_dependency 'claide', '>= 0.9.1', '< 1.1.0'
 


### PR DESCRIPTION
This is needed for a better integration with https://fastlane.ci

- Sorted #seedlist
- #seedlist is public now
- `Xcode` object has `installed` attribute that's not cached in-between runs
- Improve `#exist?` method to work with `Gem::Version` as well as plain strings (e.g. for "4.3 for Lion")
- Add and use new `#find_xcode_version` method with the above mentioned improvements

Related to https://github.com/fastlane/ci/pull/819