### PR TITLE
Use built-in way to accept Xcode license on Xcode 7.3+

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -478,12 +478,16 @@ HELP
     end
 
     def approve_license
-      license_path = "#{@path}/Contents/Resources/English.lproj/License.rtf"
-      license_id = IO.read(license_path).match(/\bEA\d{4}\b/)
-      license_plist_path = '/Library/Preferences/com.apple.dt.Xcode.plist'
-      `sudo rm -rf #{license_plist_path}`
-      `sudo /usr/libexec/PlistBuddy -c "add :IDELastGMLicenseAgreedTo string #{license_id}" #{license_plist_path}`
-      `sudo /usr/libexec/PlistBuddy -c "add :IDEXcodeVersionForAgreedToGMLicense string #{@version}" #{license_plist_path}`
+      if Gem::Version.new(version) < Gem::Version.new('7.3')
+        license_path = "#{@path}/Contents/Resources/English.lproj/License.rtf"
+        license_id = IO.read(license_path).match(/\bEA\d{4}\b/)
+        license_plist_path = '/Library/Preferences/com.apple.dt.Xcode.plist'
+        `sudo rm -rf #{license_plist_path}`
+        `sudo /usr/libexec/PlistBuddy -c "add :IDELastGMLicenseAgreedTo string #{license_id}" #{license_plist_path}`
+        `sudo /usr/libexec/PlistBuddy -c "add :IDEXcodeVersionForAgreedToGMLicense string #{@version}" #{license_plist_path}`
+      else
+        `sudo #{@path}/Contents/Developer/usr/bin/xcodebuild -license accept`
+      end
     end
 
     def available_simulators


### PR DESCRIPTION
I have some automation scripts which install Xcode, and for some reason accepting the license was not working there the way this is currently implemented. Luckily Xcode has a built-in way to do this via `sudo xcodebuild -license accept`. 

I confirmed that this is working at least all the way back to Xcode 7.3:

```bash
$ sudo /Applications/Xcode-9.3.app/Contents/Developer/usr/bin/xcodebuild -license accept
$ cat /Library/Preferences/com.apple.dt.Xcode.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
        <key>IDELastGMLicenseAgreedTo</key>
        <string>EA1478</string>
        <key>IDEXcodeVersionForAgreedToGMLicense</key>
        <string>9.3</string>
</dict>
</plist>
$ sudo /Applications/Xcode-9.2.app/Contents/Developer/usr/bin/xcodebuild -license
 accept
$ cat /Library/Preferences/com.apple.dt.Xcode.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
        <key>IDELastGMLicenseAgreedTo</key>
        <string>EA1478</string>
        <key>IDEXcodeVersionForAgreedToGMLicense</key>
        <string>9.2</string>
</dict>
</plist>
$ sudo /Applications/Xcode-8.3.3.app/Contents/Developer/usr/bin/xcodebuild -licen
se accept
$ cat /Library/Preferences/com.apple.dt.Xcode.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
        <key>IDELastGMLicenseAgreedTo</key>
        <string>EA1421</string>
        <key>IDEXcodeVersionForAgreedToGMLicense</key>
        <string>8.3.3</string>
</dict>
</plist>
$ sudo /Applications/Xcode-7.3.1.app/Contents/Developer/usr/bin/xcodebuild -license accept
$ cat /Library/Preferences/com.apple.dt.Xcode.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
        <key>IDELastGMLicenseAgreedTo</key>
        <string>EA1327</string>
        <key>IDEXcodeVersionForAgreedToGMLicense</key>
        <string>7.3.1</string>
</dict>
</plist>
```

And then installing the latest Xcode 9.4 beta 2 using these changes: 

```bash
$ be xcversion install "9.4 beta 2"
######################################################################## 100.0%
Please authenticate for Xcode installation.
Password:
/Applications/Xcode-9.4.app: accepted
source=Apple System

Xcode 9.4
Build version 9Q1019a
$ cat /Library/Preferences/com.apple.dt.Xcode.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
        <key>IDELastBetaLicenseAgreedTo</key>
        <string>EA1478</string>
        <key>IDELastGMLicenseAgreedTo</key>
        <string>EA1478</string>
        <key>IDEXcodeVersionForAgreedToBetaLicense</key>
        <string>9.4</string>
        <key>IDEXcodeVersionForAgreedToGMLicense</key>
        <string></string>
</dict>
</plist>
```