### PR TITLE
Add a system to track the progress of Xcode downloads

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -493,7 +493,7 @@ HELP
       end
     end
 
-    def download(progress, progress_block)
+    def download(progress, progress_block = nil)
       result = Curl.new.fetch(
         url: source,
         directory: CACHE_DIR,

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -22,6 +22,7 @@ module XcodeInstall
     # @param progress: parse and show the progress?
     # @param progress_block: A block that's called whenever we have an updated progress %
     #                        the parameter is a single number that's literally percent (e.g. 1, 50, 80 or 100)
+    # rubocop:disable Metrics/AbcSize
     def fetch(url: nil,
               directory: nil,
               cookies: nil,

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -6,35 +6,108 @@ require 'json'
 require 'rubygems/version'
 require 'xcode/install/command'
 require 'xcode/install/version'
+require 'shellwords'
+require 'open3'
+require 'fileutils'
 
 module XcodeInstall
   CACHE_DIR = Pathname.new("#{ENV['HOME']}/Library/Caches/XcodeInstall")
   class Curl
     COOKIES_PATH = Pathname.new('/tmp/curl-cookies.txt')
 
-    def fetch(url, directory = nil, cookies = nil, output = nil, progress = true)
+    # @param url: The URL to download
+    # @param directory: The directory to download this file into
+    # @param cookies: Any cookies we should use for the download (used for auth with Apple)
+    # @param output: A PathName for where we want to store the file
+    # @param progress: parse and show the progress?
+    # @param progress_block: A block that's called whenever we have an updated progress %
+    #                        the parameter is a single number that's literally percent (e.g. 1, 50, 80 or 100)
+    # rubocop:disable Metrics/AbcSize
+    def fetch(url: nil,
+              directory: nil,
+              cookies: nil,
+              output: nil,
+              progress: nil,
+              progress_block: nil)
+
       options = cookies.nil? ? [] : ['--cookie', cookies, '--cookie-jar', COOKIES_PATH]
-      # options << ' -vvv'
 
       uri = URI.parse(url)
       output ||= File.basename(uri.path)
       output = (Pathname.new(directory) + Pathname.new(output)) if directory
 
       retry_options = ['--retry', '3']
-      progress = progress ? '--progress-bar' : '--silent'
-      command = ['curl', *options, *retry_options, '--location', '--continue-at', '-', progress, '--output', output, url].map(&:to_s)
+      command = [
+        'curl',
+        *options,
+        *retry_options,
+        '--location',
+        '--continue-at',
+        '-',
+        '--output',
+        output,
+        url
+      ].map(&:to_s)
+
+      progress_log_file = File.join(CACHE_DIR, "progress.#{Time.now.to_i}.progress")
+      FileUtils.rm(progress_log_file) if File.exist?(progress_log_file)
 
       # Run the curl command in a loop, retry when curl exit status is 18
       # "Partial file. Only a part of the file was transferred."
       # https://curl.haxx.se/mail/archive-2008-07/0098.html
       # https://github.com/KrauseFx/xcode-install/issues/210
       3.times do
-        io = IO.popen(command)
-        io.each { |line| puts line }
-        io.close
+        command_string = command.collect(&:shellescape).join(' ')
 
-        exit_code = $?.exitstatus
-        return exit_code.zero? unless exit_code == 18
+        # Piping over all of stderr over to a temporary file
+        # the file content looks like this:
+        #  0 4766M    0 6835k    0     0   573k      0  2:21:58  0:00:11  2:21:47  902k
+        # This way we can parse the current %
+        # The header is
+        #  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+        #
+        # Discussion for this on GH: https://github.com/KrauseFx/xcode-install/issues/276
+        # It was not easily possible to reimplement the same system using built-in methods
+        # especially when it comes to resuming downloads
+        # Piping over stderror to Ruby directly didn't work, due to the lack of flushing
+        # from curl. The only reasonable way to trigger this, is to pipe things directly into a
+        # local file, and parse that, and just poll that. We could get real time updates using
+        # the `tail` command or similar, however the download task is not time sensitive enough
+        # to make this worth the extra complexity, that's why we just poll and
+        # wait for the process to be finished
+
+        command_string += " 2> #{progress_log_file}"
+
+        # Non-blocking call
+        stdin, stdout, stderr, wait_thr = Open3.popen3(command_string)
+
+        # Poll the file and see if we're done yet
+        while wait_thr.alive?
+          sleep(1) # it's not critical for this to be real-time
+          next unless File.exist?(progress_log_file) # it might take longer for it to be created
+
+          progress_content = File.read(progress_log_file).split("\r").last
+
+          # Print out the progress for the CLI
+          if progress
+            print "\r#{progress_content}%"
+            $stdout.flush
+          end
+
+          # Call back the block for other processes that might be interested
+          matched = progress_content.match(/^\s*(\d)/)
+          next unless matched.length == 2
+          percent = matched[1].to_i
+          progress_block.call(percent) if progress_block
+        end
+
+        # as we're not making use of the block-based syntax
+        # we need to manually close those
+        stdin.close
+        stdout.close
+        stderr.close
+
+        return wait_thr.value.success? if wait_thr.value.success?
       end
       false
     ensure
@@ -58,13 +131,20 @@ module XcodeInstall
       File.symlink?(SYMLINK_PATH) ? SYMLINK_PATH : nil
     end
 
-    def download(version, progress, url = nil)
+    def download(version, progress, url = nil, progress_block = nil)
       xcode = find_xcode_version(version) if url.nil?
       return if url.nil? && xcode.nil?
 
       dmg_file = Pathname.new(File.basename(url || xcode.path))
 
-      result = Curl.new.fetch(url || xcode.url, CACHE_DIR, url ? nil : spaceship.cookie, dmg_file, progress)
+      result = Curl.new.fetch(
+        url: url || xcode.url,
+        directory: CACHE_DIR,
+        cookies: url ? nil : spaceship.cookie,
+        output: dmg_file,
+        progress: progress,
+        progress_block: progress_block
+      )
       result ? CACHE_DIR + dmg_file : nil
     end
 
@@ -184,8 +264,9 @@ HELP
       FileUtils.rm_f(dmg_path) if clean
     end
 
-    def install_version(version, switch = true, clean = true, install = true, progress = true, url = nil, show_release_notes = true)
-      dmg_path = get_dmg(version, progress, url)
+    # rubocop:disable Metrics/ParameterLists
+    def install_version(version, switch = true, clean = true, install = true, progress = true, url = nil, show_release_notes = true, progress_block = nil)
+      dmg_path = get_dmg(version, progress, url, progress_block)
       fail Informative, "Failed to download Xcode #{version}." if dmg_path.nil?
 
       if install
@@ -267,7 +348,7 @@ HELP
       `sudo /usr/sbin/dseditgroup -o edit -t group -a staff _developer`
     end
 
-    def get_dmg(version, progress = true, url = nil)
+    def get_dmg(version, progress = true, url = nil, progress_block = nil)
       if url
         path = Pathname.new(url)
         return path if path.exist?
@@ -277,7 +358,7 @@ HELP
         return cache_path if cache_path.exist?
       end
 
-      download(version, progress, url)
+      download(version, progress, url, progress_block)
     end
 
     def fetch_seedlist
@@ -412,8 +493,13 @@ HELP
       end
     end
 
-    def download(progress)
-      result = Curl.new.fetch(source, CACHE_DIR, nil, nil, progress)
+    def download(progress, progress_block)
+      result = Curl.new.fetch(
+        url: source,
+        directory: CACHE_DIR,
+        progress: progress,
+        progress_block: progress_block
+      )
       result ? dmg_path : nil
     end
 

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -110,6 +110,7 @@ module XcodeInstall
       false
     ensure
       FileUtils.rm_f(COOKIES_PATH)
+      FileUtils.rm_f(progress_log_file)
     end
   end
 

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -23,6 +23,7 @@ module XcodeInstall
     # @param progress_block: A block that's called whenever we have an updated progress %
     #                        the parameter is a single number that's literally percent (e.g. 1, 50, 80 or 100)
     # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/CyclomaticComplexity
     def fetch(url: nil,
               directory: nil,
               cookies: nil,
@@ -80,16 +81,20 @@ module XcodeInstall
         # library doesn't seem to support writing tests for it
         stdin, stdout, stderr, wait_thr = Open3.popen3(command_string)
 
-        # Poll the file and see if we're done yet
-        while wait_thr.alive?
-          sleep(0.5) # it's not critical for this to be real-time
-          next unless File.exist?(progress_log_file) # it might take longer for it to be created
+        # Wait for the process to be up and the log file to be there
+        sleep(0.5) while wait_thr.alive? && !File.exist?(progress_log_file)
 
-          progress_content = File.read(progress_log_file).split("\r").last
+        # Poll the file and see if we're done yet
+        progress_file_ref ||= File.open(progress_log_file, 'r')
+        while wait_thr.alive?
+          progress_file_ref.seek(0, IO::SEEK_END)
+          sleep(1)
+          progress_content = progress_file_ref.gets.to_s.strip
+          next if progress_content.empty?
 
           # Print out the progress for the CLI
           if progress
-            print "\r#{progress_content}%"
+            $stdout.print "\r#{progress_content}%"
             $stdout.flush
           end
 
@@ -112,6 +117,7 @@ module XcodeInstall
     ensure
       FileUtils.rm_f(COOKIES_PATH)
       FileUtils.rm_f(progress_log_file)
+      progress_file_ref.close if defined?(progress_file_ref)
     end
   end
 

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -22,7 +22,6 @@ module XcodeInstall
     # @param progress: parse and show the progress?
     # @param progress_block: A block that's called whenever we have an updated progress %
     #                        the parameter is a single number that's literally percent (e.g. 1, 50, 80 or 100)
-    # rubocop:disable Metrics/AbcSize
     def fetch(url: nil,
               directory: nil,
               cookies: nil,
@@ -34,6 +33,25 @@ module XcodeInstall
       uri = URI.parse(url)
       output ||= File.basename(uri.path)
       output = (Pathname.new(directory) + Pathname.new(output)) if directory
+
+      # Piping over all of stderr over to a temporary file
+      # the file content looks like this:
+      #  0 4766M    0 6835k    0     0   573k      0  2:21:58  0:00:11  2:21:47  902k
+      # This way we can parse the current %
+      # The header is
+      #  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+      #
+      # Discussion for this on GH: https://github.com/KrauseFx/xcode-install/issues/276
+      # It was not easily possible to reimplement the same system using built-in methods
+      # especially when it comes to resuming downloads
+      # Piping over stderror to Ruby directly didn't work, due to the lack of flushing
+      # from curl. The only reasonable way to trigger this, is to pipe things directly into a
+      # local file, and parse that, and just poll that. We could get real time updates using
+      # the `tail` command or similar, however the download task is not time sensitive enough
+      # to make this worth the extra complexity, that's why we just poll and
+      # wait for the process to be finished
+      progress_log_file = File.join(CACHE_DIR, "progress.#{Time.now.to_i}.progress")
+      FileUtils.rm_f(progress_log_file)
 
       retry_options = ['--retry', '3']
       command = [
@@ -48,36 +66,15 @@ module XcodeInstall
         url
       ].map(&:to_s)
 
-      progress_log_file = File.join(CACHE_DIR, "progress.#{Time.now.to_i}.progress")
-      FileUtils.rm(progress_log_file) if File.exist?(progress_log_file)
+      command_string = command.collect(&:shellescape).join(' ')
+      command_string += " 2> #{progress_log_file}" # to not run shellescape on the `2>`
 
       # Run the curl command in a loop, retry when curl exit status is 18
       # "Partial file. Only a part of the file was transferred."
       # https://curl.haxx.se/mail/archive-2008-07/0098.html
       # https://github.com/KrauseFx/xcode-install/issues/210
       3.times do
-        command_string = command.collect(&:shellescape).join(' ')
-
-        # Piping over all of stderr over to a temporary file
-        # the file content looks like this:
-        #  0 4766M    0 6835k    0     0   573k      0  2:21:58  0:00:11  2:21:47  902k
-        # This way we can parse the current %
-        # The header is
-        #  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-        #
-        # Discussion for this on GH: https://github.com/KrauseFx/xcode-install/issues/276
-        # It was not easily possible to reimplement the same system using built-in methods
-        # especially when it comes to resuming downloads
-        # Piping over stderror to Ruby directly didn't work, due to the lack of flushing
-        # from curl. The only reasonable way to trigger this, is to pipe things directly into a
-        # local file, and parse that, and just poll that. We could get real time updates using
-        # the `tail` command or similar, however the download task is not time sensitive enough
-        # to make this worth the extra complexity, that's why we just poll and
-        # wait for the process to be finished
-
-        command_string += " 2> #{progress_log_file}"
-
-        # Non-blocking call
+        # Non-blocking call of Open3
         # We're not using the block based syntax, as the bacon testing
         # library doesn't seem to support writing tests for it
         stdin, stdout, stderr, wait_thr = Open3.popen3(command_string)

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -159,6 +159,7 @@ module XcodeInstall
       begin
         parsed_version = Gem::Version.new(version)
       rescue ArgumentError
+        nil
       end
 
       seedlist.each do |current_seed|

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -155,9 +155,15 @@ module XcodeInstall
       # or they might pass an actual Gem::Version
       #   Gem::Version.new("8.0.0")
       # which should automatically match with "Xcode 8"
+
+      begin
+        parsed_version = Gem::Version.new(version)
+      rescue ArgumentError
+      end
+
       seedlist.each do |current_seed|
-        return current_seed if current_seed.version == Gem::Version.new(version)
         return current_seed if current_seed.name == version
+        return current_seed if parsed_version && current_seed.version == parsed_version
       end
       nil
     end

--- a/spec/curl_spec.rb
+++ b/spec/curl_spec.rb
@@ -18,7 +18,7 @@ module XcodeInstall
       curl = XcodeInstall::Curl.new
       result = nil
       XcodeInstall.silence_stderr do
-        result = curl.fetch('http://0.0.0.0/test')
+        result = curl.fetch(url: 'http://0.0.0.0/test')
       end
       result.should == false
     end

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -12,26 +12,26 @@ module XcodeInstall
       end
 
       it 'downloads and installs' do
-        Installer.any_instance.expects(:download).with('6.3', true, nil).returns('/some/path')
+        Installer.any_instance.expects(:download).with('6.3', true, nil, nil).returns('/some/path')
         Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', true, true)
         Command::Install.run(['6.3'])
       end
 
       it 'downloads and installs with custom HTTP URL' do
         url = 'http://yolo.com/xcode.dmg'
-        Installer.any_instance.expects(:download).with('6.3', true, url).returns('/some/path')
+        Installer.any_instance.expects(:download).with('6.3', true, url, nil).returns('/some/path')
         Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', true, true)
         Command::Install.run(['6.3', "--url=#{url}"])
       end
 
       it 'downloads and installs and does not switch if --no-switch given' do
-        Installer.any_instance.expects(:download).with('6.3', true, nil).returns('/some/path')
+        Installer.any_instance.expects(:download).with('6.3', true, nil, nil).returns('/some/path')
         Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', false, true)
         Command::Install.run(['6.3', '--no-switch'])
       end
 
       it 'downloads without progress if switch --no-progress is given' do
-        Installer.any_instance.expects(:download).with('6.3', false, nil).returns('/some/path')
+        Installer.any_instance.expects(:download).with('6.3', false, nil, nil).returns('/some/path')
         Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', true, true)
         Command::Install.run(['6.3', '--no-progress'])
       end

--- a/spec/installer_spec.rb
+++ b/spec/installer_spec.rb
@@ -1,0 +1,100 @@
+require File.expand_path('../spec_helper', __FILE__)
+
+module XcodeInstall
+  describe '#fetch' do
+    before do
+      client = mock
+      client.stubs(:cookie).returns('customCookie')
+      Spaceship::PortalClient.stubs(:login).returns(client)
+    end
+
+    it 'downloads the file and calls the `progress_block` with the percentage' do
+      installer = Installer.new
+
+      xcode = XcodeInstall::Xcode.new('name' => 'Xcode 9.3',
+                                      'files' => [{
+                                        'remotePath' => '/Developer_Tools/Xcode_9.3/Xcode_9.3.xip'
+                                      }])
+
+      installer.stubs(:fetch_seedlist).returns([xcode])
+
+      stdin = 'stdin'
+      stdout = 'stdout'
+      stderr = 'stderr'
+      wait_thr = 'wait_thr'
+
+      stdin.stubs(:close)
+      stdout.stubs(:close)
+      stderr.stubs(:close)
+
+      current_time = '123123'
+      Time.stubs(:now).returns(current_time)
+
+      xip_path = File.join(File.expand_path('~'), '/Library/Caches/XcodeInstall/Xcode_9.3.xip')
+      progress_log_file = File.join(File.expand_path('~'), "/Library/Caches/XcodeInstall/progress.#{current_time}.progress")
+
+      command = [
+        'curl',
+        '--cookie customCookie',
+        '--cookie-jar /tmp/curl-cookies.txt',
+        '--retry 3',
+        '--location',
+        '--continue-at -',
+        "--output #{xip_path}",
+        'https://developer.apple.com/devcenter/download.action\\?path\\=/Developer_Tools/Xcode_9.3/Xcode_9.3.xip',
+        "2> #{progress_log_file}"
+      ]
+      Open3.stubs(:popen3).with(command.join(' ')).returns([stdin, stdout, stderr, wait_thr])
+
+      wait_thr.stubs(:alive?).returns(true)
+
+      thr_value = 'thr_value'
+      wait_thr.stubs(:value).returns(thr_value)
+      thr_value.stubs(:success?).returns(true)
+
+      installer.stubs(:install_dmg).with(Pathname.new(xip_path), '-9.3', false, false)
+
+      Thread.new do
+        sleep(1)
+        File.write(progress_log_file, '  0 4766M    0 6835k    0     0   573k      0  2:21:58  0:00:11  2:21:47  902k')
+        sleep(1)
+        File.write(progress_log_file, ' 5 4766M    0 6835k    0     0   573k      0  2:21:58  0:00:11  2:21:47  902k')
+        sleep(1)
+        File.write(progress_log_file, '50 4766M    0 6835k    0     0   573k      0  2:21:58  0:00:11  2:21:47  902k')
+        sleep(1)
+        File.write(progress_log_file, '100 4766M    0 6835k    0     0   573k      0  2:21:58  0:00:11  2:21:47  902k')
+        sleep(0.5)
+        wait_thr.stubs(:alive?).returns(false)
+      end
+
+      percentages = []
+      installer.install_version(
+        # version: the version to install
+        '9.3',
+        # `should_switch
+        false,
+        # `should_clean`
+        false, # false for now for faster debugging
+        # `should_install`
+        true,
+        # `progress`
+        false,
+        # `url` is nil, as we don't have a custom source
+        nil,
+        # `show_release_notes` is `false`, as this is a non-interactive machine
+        false,
+        # `progress_block` be updated on the download progress
+        proc do |percent|
+          percentages << percent
+        end
+      )
+
+      percentages.each do |current_percent|
+        # Verify all reported percentages are between 0 and 100
+        current_percent.should.be.close(50, 50)
+      end
+      # Verify we got a good amount of percentages reported
+      percentages.count.should.be.close(8, 2)
+    end
+  end
+end

--- a/spec/installer_spec.rb
+++ b/spec/installer_spec.rb
@@ -94,6 +94,7 @@ module XcodeInstall
         current_percent.should.be.close(50, 50)
       end
       # Verify we got a good amount of percentages reported
+      puts percentages
       percentages.count.should.be.close(8, 2)
     end
   end

--- a/spec/installer_spec.rb
+++ b/spec/installer_spec.rb
@@ -94,8 +94,7 @@ module XcodeInstall
         current_percent.should.be.close(50, 50)
       end
       # Verify we got a good amount of percentages reported
-      puts percentages
-      percentages.count.should.be.close(8, 2)
+      percentages.count.should.be.close(8, 4)
     end
   end
 end


### PR DESCRIPTION
<img width="677" alt="screenshot 2018-05-10 05 37 31" src="https://user-images.githubusercontent.com/869950/39878537-edc52886-5478-11e8-90d5-cb82aed4bcd4.png">

This was a lot more difficult than expected, the comments in the code should explain everything 👍

This allows us to pass a `progress_block` to stay up to date on the installation progress of Xcode

Closes https://github.com/KrauseFx/xcode-install/issues/276