### PR TITLE
Try to recover when Spotlight returns no results by searching `/Applications` folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,11 @@ XcodeInstall automatically installs additional components so that it is immediat
 commandline. Unfortunately, Xcode will load third-party plugins even in that situation, which leads
 to a dialog popping up. Feel free to dupe [the radar][5]. 📡
 
-XcodeInstall uses the Spotlight index to locate installed versions of Xcode. If you use it while
+XcodeInstall normally relies on the Spotlight index to locate installed versions of Xcode. If you use it while
 indexing is happening, it might show inaccurate results and it will not be able to see installed
-versions on unindexed volumes.
+versions on unindexed volumes. 
+
+To workaround the Spotlight limitation, XcodeInstall searches `/Applications` folder to locate Xcodes when Spotlight is disabled on the machine, or when Spotlight query for Xcode does not return any results. But it still won't work if your Xcodes are located under `/Applications` folder.
 
 ## Thanks
 

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -387,6 +387,7 @@ HELP
         'if [ "$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" \
         "{}/Contents/Info.plist" 2>/dev/null)" == "com.apple.dt.Xcode" ]; then echo "{}"; fi' ';'`.split("\n")
       end
+      result
     end
 
     def parse_seedlist(seedlist)

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -381,11 +381,13 @@ HELP
     end
 
     def installed
-      unless (`mdutil -s /` =~ /disabled/).nil?
-        raise 'Please enable Spotlight indexing for /Applications.'
+      if `mdutil -s /` =~ /disabled/
+        `find /Applications -name '*.app' -type d -maxdepth 1 -exec sh -c \
+'if [ "$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" \
+"{}/Contents/Info.plist" 2>/dev/null)" == "com.apple.dt.Xcode" ]; then echo "{}"; fi' ';'`.split("\n")
+      else
+        `mdfind "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'" 2>/dev/null`.split("\n")
       end
-
-      `mdfind "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'" 2>/dev/null`.split("\n")
     end
 
     def parse_seedlist(seedlist)

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -381,12 +381,11 @@ HELP
     end
 
     def installed
-      if `mdutil -s /` =~ /disabled/
-        `find /Applications -name '*.app' -type d -maxdepth 1 -exec sh -c \
-'if [ "$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" \
-"{}/Contents/Info.plist" 2>/dev/null)" == "com.apple.dt.Xcode" ]; then echo "{}"; fi' ';'`.split("\n")
-      else
-        `mdfind "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'" 2>/dev/null`.split("\n")
+      result = `mdfind "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'" 2>/dev/null`.split("\n")
+      if result.empty?
+        result = `find /Applications -name '*.app' -type d -maxdepth 1 -exec sh -c \
+        'if [ "$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" \
+        "{}/Contents/Info.plist" 2>/dev/null)" == "com.apple.dt.Xcode" ]; then echo "{}"; fi' ';'`.split("\n")
       end
     end
 


### PR DESCRIPTION
This PR improves #268 a little bit more by searching `/Applications` folder not only if Spotlight is disabled, but also if it returns no results.

I've experienced this on CircleCI while trying to install additional simulators in my builds. In CircleCI, Spotlight was not disabled, but it simply wouldn't return any results.

Also added a simple description to Readme about the workaround.