### PR TITLE
Fix List Order For Xcode 10

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -297,7 +297,7 @@ HELP
     end
 
     def list
-      list_annotated(list_versions.sort)
+      list_annotated(list_versions.sort_by(&:to_f))
     end
 
     def rm_list_cache

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -25,8 +25,8 @@ module XcodeInstall
 
     describe '#list' do
       it 'lists all versions' do
-        fake_xcodes '1', '2.3', '3 some', '4 beta'
-        installer.list.should == "1\n2.3\n3 some\n4 beta"
+        fake_xcodes '1', '2.3', '2.3.1', '2.3.2', '3 some', '4 beta', '10 beta'
+        installer.list.should == "1\n2.3\n2.3.1\n2.3.2\n3 some\n4 beta\n10 beta"
       end
     end
   end


### PR DESCRIPTION
Since we are now on the 10's for Xcode, they should be displayed at the end of the list, not at the beginning. Fixes the sort function in `Installer` to sort by `.sort_by(&:to_f)`.