### PR TITLE
Fixes #292 by returning a success state

### DIFF
--- a/lib/xcode/install/install.rb
+++ b/lib/xcode/install/install.rb
@@ -37,7 +37,10 @@ module XcodeInstall
         super
 
         help! 'A VERSION argument is required.' unless @version
-        fail Informative, "Version #{@version} already installed." if @installer.installed?(@version) && !@force
+        if @installer.installed?(@version) && !@force
+          print "Version #{@version} already installed."
+          exit(0)
+        end
         fail Informative, "Version #{@version} doesn't exist." unless @url || @installer.exist?(@version)
         fail Informative, "Invalid URL: `#{@url}`" unless !@url || @url =~ /\A#{URI.regexp}\z/
       end


### PR DESCRIPTION
Return a success state (e.g. `0`) if version is already installed, rather than a non-zero failure state.