### PR TITLE
added an annotation to beta in list

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -293,7 +293,12 @@ HELP
 
     def list_annotated(xcodes_list)
       installed = installed_versions.map(&:version)
-      xcodes_list.map { |x| installed.include?(x) ? "#{x} (installed)" : x }.join("\n")
+      xcodes_list.map do |x|
+        xcode_version = x.split(' ').first # exclude "beta N", "for Lion".
+        xcode_version << '.0' unless xcode_version.include?('.')
+
+        installed.include?(xcode_version) ? "#{x} (installed)" : x
+      end.join("\n")
     end
 
     def list

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -4,7 +4,6 @@ module XcodeInstall
   describe Command::List do
     before do
       installer.stubs(:exists).returns(true)
-      installer.stubs(:installed_versions).returns([])
     end
 
     def installer
@@ -23,10 +22,35 @@ module XcodeInstall
       installer.stubs(:xcodes).returns(xcodes)
     end
 
+    def fake_installed_xcode(name)
+      xcode_path = "/Applications/Xcode-#{name}.app"
+      xcode_version = name
+      xcode_version << '.0' unless name.include? '.'
+
+      installed_xcode = InstalledXcode.new(xcode_path)
+      installed_xcode.stubs(:version).returns(xcode_version)
+      installed_xcode.stubs(:bundle_version).returns(Gem::Version.new(xcode_version))
+      installed_xcode
+    end
+
+    def fake_installed_xcodes(*names)
+      xcodes = names.map { |name| fake_installed_xcode(name) }
+      installer.stubs(:installed_versions).returns(xcodes)
+    end
+
     describe '#list' do
       it 'lists all versions' do
         fake_xcodes '1', '2.3', '2.3.1', '2.3.2', '3 some', '4 beta', '10 beta'
+        fake_installed_xcodes
         installer.list.should == "1\n2.3\n2.3.1\n2.3.2\n3 some\n4 beta\n10 beta"
+      end
+    end
+
+    describe '#list_annotated' do
+      it 'lists all versions with annotations' do
+        fake_xcodes '1', '2.3', '2.3.1', '2.3.2', '3 some', '4.3.1 for Lion', '9.4.1', '10 beta'
+        fake_installed_xcodes '2.3', '4.3.1', '10'
+        installer.list.should == "1\n2.3 (installed)\n2.3.1\n2.3.2\n3 some\n4.3.1 for Lion (installed)\n9.4.1\n10 beta (installed)"
       end
     end
   end


### PR DESCRIPTION
Currently, Xcode beta versions are not annotated, when you call `xcversion list`.
This fix should be applicable for ancient Xcode versions as well, such as "4.3.1 for Lion", although nobody would use them now.

**before**
<img width="185" alt="screen shot 2018-07-16 at 1 11 26" src="https://user-images.githubusercontent.com/25413198/42735798-58a673b2-8895-11e8-844a-cd799a6496f6.png">
**after**
<img width="182" alt="screen shot 2018-07-16 at 1 12 02" src="https://user-images.githubusercontent.com/25413198/42735802-5c720f92-8895-11e8-9d61-1cd1814be1eb.png">

This is reported in [the comment](https://github.com/KrauseFx/xcode-install/issues/291#issuecomment-403856335) of #291 .