### PR TITLE
Fix xcversion fails to install a new Xcode beta to the same location

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -277,7 +277,7 @@ HELP
       fail Informative, "Failed to download Xcode #{version}." if dmg_path.nil?
 
       if install
-        install_dmg(dmg_path, "-#{version.to_s.split(' ')[0]}", switch, clean)
+        install_dmg(dmg_path, "-#{version.to_s.split(' ').join('.')}", switch, clean)
       else
         puts "Downloaded Xcode #{version} to '#{dmg_path}'"
       end


### PR DESCRIPTION
Currently all Xcode betas are installed under the name `Xcode-beta.app`. If you have Xcode 10 beta 5 installed, and you install Xcode 10 beta 6, the installation will fail when it copies the new app to the same location. The downloaded `.xip` file also gets deleted even the installation fails, so you end up having to download it again (after deleting or renaming `/Applications/Xcode-beta.app`).

This patch follows the following naming for betas:

`xcversion install 10 beta 6` installs to `/Applications/Xcode-10.beta.6.app`

The installation location remains unchanged for non-beta versions.

Since it won't overwrite the old version, you can go back to previous beta if the new beta goes wrong with your project (e.g. Crashlytics, Fabric, GoogleAnalytics don't compile with Xcode 10 beta 5 while they do with Xcode 10 beta 4) and Apple doesn't keep old betas on Developer Center.