### PR TITLE
Fix undefined method error

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -95,7 +95,7 @@ module XcodeInstall
 
           # Call back the block for other processes that might be interested
           matched = progress_content.match(/^\s*(\d+)/)
-          next unless matched.length == 2
+          next unless matched && matched.length == 2
           percent = matched[1].to_i
           progress_block.call(percent) if progress_block
         end


### PR DESCRIPTION
Fixes the following error:
```
.../xcode-install-2.4.4/lib/xcode/install.rb:98:in `block in fetch': undefined method `length' for nil:NilClass (NoMethodError)
	from .../xcode-install-2.4.4/lib/xcode/install.rb:77:in `times'
	from .../xcode-install-2.4.4/lib/xcode/install.rb:77:in `fetch'
	from .../xcode-install-2.4.4/lib/xcode/install.rb:140:in `download'
	from .../xcode-install-2.4.4/lib/xcode/install.rb:371:in `get_dmg'
	from .../xcode-install-2.4.4/lib/xcode/install.rb:276:in `install_version'
	from .../xcode-install-2.4.4/lib/xcode/install/install.rb:49:in `run'
	from .../claide-1.0.2/lib/claide/command.rb:334:in `run'
	from .../xcode-install-2.4.4/bin/xcversion:12:in `<top (required)>'
	from .../ruby-2.3.1/bin/xcversion:23:in `load'
	from .../ruby-2.3.1/bin/xcversion:23:in `<main>'
	from .../ruby-2.3.1/bin/ruby_executable_hooks:24:in `eval'
	from .../ruby-2.3.1/bin/ruby_executable_hooks:24:in `<main>'
```