### PR TITLE
Fix find command error

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -388,7 +388,7 @@ HELP
     def installed
       result = `mdfind "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'" 2>/dev/null`.split("\n")
       if result.empty?
-        result = `find /Applications -name '*.app' -type d -maxdepth 1 -exec sh -c \
+        result = `find /Applications -maxdepth 1 -name '*.app' -type d -exec sh -c \
         'if [ "$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" \
         "{}/Contents/Info.plist" 2>/dev/null)" == "com.apple.dt.Xcode" ]; then echo "{}"; fi' ';'`.split("\n")
       end


### PR DESCRIPTION
Fix warning from find command:

`find: warning: you have specified the -maxdepth option after a non-option argument -name, but options are not positional (-maxdepth affects tests specified before it as well as those specified after it).  Please specify options before other arguments.`