### PR TITLE
Support reading version from .xcode-version

### DIFF
--- a/lib/xcode/install/install.rb
+++ b/lib/xcode/install/install.rb
@@ -22,7 +22,8 @@ module XcodeInstall
 
       def initialize(argv)
         @installer = Installer.new
-        @version = argv.shift_argument || File.read('.xcode-version') rescue nil # rubocop:disable Style/RescueModifier, Lint/RescueWithoutErrorClass
+        @version = argv.shift_argument
+        @version ||= File.read('.xcode-version') if File.exist?('.xcode-version')
         @url = argv.option('url')
         @force = argv.flag?('force', false)
         @should_clean = argv.flag?('clean', true)

--- a/lib/xcode/install/install.rb
+++ b/lib/xcode/install/install.rb
@@ -22,7 +22,7 @@ module XcodeInstall
 
       def initialize(argv)
         @installer = Installer.new
-        @version = argv.shift_argument
+        @version = argv.shift_argument || File.read('.xcode-version') rescue nil # rubocop:disable Style/RescueModifier, Lint/RescueWithoutErrorClass
         @url = argv.option('url')
         @force = argv.flag?('force', false)
         @should_clean = argv.flag?('clean', true)

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -35,6 +35,13 @@ module XcodeInstall
         Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', true, true)
         Command::Install.run(['6.3', '--no-progress'])
       end
+
+      it 'reads .xcode-version' do
+        Installer.any_instance.expects(:download).with('6.3', true, nil, nil).returns('/some/path')
+        Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', true, true)
+        File.expects(:read).returns('6.3')
+        Command::Install.run([])
+      end
     end
 
     it 'parses hdiutil output' do

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -39,6 +39,7 @@ module XcodeInstall
       it 'reads .xcode-version' do
         Installer.any_instance.expects(:download).with('6.3', true, nil, nil).returns('/some/path')
         Installer.any_instance.expects(:install_dmg).with('/some/path', '-6.3', true, true)
+        File.expects(:exist?).with('.xcode-version').returns(true)
         File.expects(:read).returns('6.3')
         Command::Install.run([])
       end


### PR DESCRIPTION
Automatically take current Xcode from `.xcode-version` when running
`xcversion install`.