### PR TITLE
Don't exit 1 if CLI tools are already installed

### DIFF
--- a/lib/xcode/install/cli.rb
+++ b/lib/xcode/install/cli.rb
@@ -5,7 +5,10 @@ module XcodeInstall
       self.summary = 'Installs Xcode Command Line Tools.'
 
       def run
-        fail Informative, 'Xcode CLI Tools are already installed.' if installed?
+        if installed?
+          print 'Xcode CLI Tools are already installed.'
+          exit(0)
+        end
         install
       end
 


### PR DESCRIPTION
Previously `xcversion install-cli-tools` would exit 1 if they were
already installed, but `xcversion install VERSION` would exit 0. This
makes them have the same behavior.