### PR TITLE
Use cached .xip file if configure 'XCODE_INSTALL_CACHE_DIR'

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -364,8 +364,8 @@ HELP
         return path if path.exist?
       end
       if ENV.key?('XCODE_INSTALL_CACHE_DIR')
-        Pathname.glob(ENV['XCODE_INSTALL_CACHE_DIR'] '/*')).each do |path|
-          return path if /^xcode_#{version}\.dmg|xip$/ =~ path.basename.to_s
+        Pathname.glob(ENV['XCODE_INSTALL_CACHE_DIR'] + '/*').each do |fpath|
+          return fpath if /^xcode_#{version}\.dmg|xip$/ =~ fpath.basename.to_s
         end
       end
 

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -364,8 +364,10 @@ HELP
         return path if path.exist?
       end
       if ENV.key?('XCODE_INSTALL_CACHE_DIR')
-        cache_path = Pathname.new(ENV['XCODE_INSTALL_CACHE_DIR']) + Pathname.new("xcode-#{version}.dmg")
-        return cache_path if cache_path.exist?
+        dmg_cache_path = Pathname.new(ENV['XCODE_INSTALL_CACHE_DIR']) + Pathname.new("xcode-#{version}.dmg")
+        xip_cache_path = Pathname.new(ENV['XCODE_INSTALL_CACHE_DIR']) + Pathname.new("xcode_#{version}.xip")
+        return dmg_cache_path if dmg_cache_path.exist?
+        return xip_cache_path if xip_cache_path.exist?
       end
 
       download(version, progress, url, progress_block)

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -364,10 +364,9 @@ HELP
         return path if path.exist?
       end
       if ENV.key?('XCODE_INSTALL_CACHE_DIR')
-        dmg_cache_path = Pathname.new(ENV['XCODE_INSTALL_CACHE_DIR']) + Pathname.new("xcode-#{version}.dmg")
-        xip_cache_path = Pathname.new(ENV['XCODE_INSTALL_CACHE_DIR']) + Pathname.new("xcode_#{version}.xip")
-        return dmg_cache_path if dmg_cache_path.exist?
-        return xip_cache_path if xip_cache_path.exist?
+        Pathname.glob(ENV['XCODE_INSTALL_CACHE_DIR'] '/*')).each do |path|
+          return path if /^xcode_#{version}\.dmg|xip$/ =~ path.basename.to_s
+        end
       end
 
       download(version, progress, url, progress_block)


### PR DESCRIPTION
`XCODE_INSTALL_CACHE_DIR` support only `.dmg` file. But recently Xcode install file is `.xip` so I want to cached file `.xip`.