### PR TITLE
Disable reading users' curlrc files

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -57,6 +57,7 @@ module XcodeInstall
       retry_options = ['--retry', '3']
       command = [
         'curl',
+        '--disable',
         *options,
         *retry_options,
         '--location',

--- a/spec/installer_spec.rb
+++ b/spec/installer_spec.rb
@@ -35,6 +35,7 @@ module XcodeInstall
 
       command = [
         'curl',
+        '--disable',
         '--cookie customCookie',
         '--cookie-jar /tmp/curl-cookies.txt',
         '--retry 3',


### PR DESCRIPTION
This file can contain `progress-bar` which breaks the output parsing of
xcversion.